### PR TITLE
feat: tactical design system — dark palette + dark-only mode

### DIFF
--- a/components/DarkLightMode/providers.tsx
+++ b/components/DarkLightMode/providers.tsx
@@ -2,13 +2,17 @@
 
 import { ThemeProvider, useTheme } from "next-themes";
 import { Toaster } from "@/components/ui/sonner";
+import { ThemeToggle } from "@/components/DarkLightMode/theme-toggle";
 
-// Site is dark-only — forcedTheme locks next-themes so no toggle is needed.
+// ThemeProvider must SSR so next-themes injects its inline script in HTML; deferring it to post-hydration triggers React 19's client <script> warning.
 export default function Providers({ children }: { children: React.ReactNode }) {
   return (
-    <ThemeProvider attribute="class" forcedTheme="dark">
+    <ThemeProvider enableSystem attribute="class" defaultTheme="system">
       {children}
       <ToasterProvider />
+      <div className="fixed right-6 bottom-6">
+        <ThemeToggle />
+      </div>
     </ThemeProvider>
   );
 }

--- a/components/DarkLightMode/providers.tsx
+++ b/components/DarkLightMode/providers.tsx
@@ -2,17 +2,13 @@
 
 import { ThemeProvider, useTheme } from "next-themes";
 import { Toaster } from "@/components/ui/sonner";
-import { ThemeToggle } from "@/components/DarkLightMode/theme-toggle";
 
-// ThemeProvider must SSR so next-themes injects its inline script in HTML; deferring it to post-hydration triggers React 19’s client <script> warning.
+// Site is dark-only — forcedTheme locks next-themes so no toggle is needed.
 export default function Providers({ children }: { children: React.ReactNode }) {
   return (
-    <ThemeProvider enableSystem attribute="class" defaultTheme="system">
+    <ThemeProvider attribute="class" forcedTheme="dark">
       {children}
       <ToasterProvider />
-      <div className="fixed right-6 bottom-6">
-        <ThemeToggle />
-      </div>
     </ThemeProvider>
   );
 }

--- a/styles/theme.css
+++ b/styles/theme.css
@@ -1,28 +1,58 @@
 :root {
   --radius: 0.25rem;
 
-  /* Base — dark by default, this site is always dark */
-  --background: oklch(0.08 0 0);         /* near-black */
-  --foreground: oklch(0.92 0 0);         /* off-white */
-  --card: oklch(0.12 0 0);              /* slightly lighter than bg */
+  /* Light mode — muted tactical tones */
+  --background: oklch(0.96 0 0);
+  --foreground: oklch(0.10 0 0);
+  --card: oklch(1 0 0);
+  --card-foreground: oklch(0.10 0 0);
+  --popover: oklch(1 0 0);
+  --popover-foreground: oklch(0.10 0 0);
+  --primary: oklch(0.10 0 0);
+  --primary-foreground: oklch(0.96 0 0);
+  --secondary: oklch(0.90 0 0);
+  --secondary-foreground: oklch(0.10 0 0);
+  --muted: oklch(0.90 0 0);
+  --muted-foreground: oklch(0.45 0 0);
+  --accent: oklch(0.90 0 0);
+  --accent-foreground: oklch(0.10 0 0);
+  --destructive: oklch(0.577 0.245 27.325);
+  --border: oklch(0 0 0 / 12%);
+  --input: oklch(0 0 0 / 10%);
+  --ring: oklch(0.45 0 0);
+  --tactical: oklch(0.65 0.13 75);
+  --tactical-foreground: oklch(0.96 0 0);
+
+  --sidebar: oklch(0.92 0 0);
+  --sidebar-foreground: oklch(0.10 0 0);
+  --sidebar-primary: oklch(0.10 0 0);
+  --sidebar-primary-foreground: oklch(0.96 0 0);
+  --sidebar-accent: oklch(0.88 0 0);
+  --sidebar-accent-foreground: oklch(0.10 0 0);
+  --sidebar-border: oklch(0 0 0 / 10%);
+  --sidebar-ring: oklch(0.45 0 0);
+}
+
+.dark {
+  --background: oklch(0.08 0 0);
+  --foreground: oklch(0.92 0 0);
+  --card: oklch(0.12 0 0);
   --card-foreground: oklch(0.92 0 0);
   --popover: oklch(0.12 0 0);
   --popover-foreground: oklch(0.92 0 0);
-  --primary: oklch(0.92 0 0);           /* white — main interactive color */
+  --primary: oklch(0.92 0 0);
   --primary-foreground: oklch(0.08 0 0);
-  --secondary: oklch(0.18 0 0);         /* dark gray — secondary surfaces */
+  --secondary: oklch(0.18 0 0);
   --secondary-foreground: oklch(0.92 0 0);
   --muted: oklch(0.18 0 0);
-  --muted-foreground: oklch(0.55 0 0);  /* dim text */
+  --muted-foreground: oklch(0.55 0 0);
   --accent: oklch(0.18 0 0);
   --accent-foreground: oklch(0.92 0 0);
-  --destructive: oklch(0.577 0.245 27.325);
+  --destructive: oklch(0.704 0.191 22.216);
   --border: oklch(1 0 0 / 10%);
   --input: oklch(1 0 0 / 12%);
   --ring: oklch(0.55 0 0);
-
-  /* Tactical accent — amber, swap this out when palette is decided */
-  --tactical: oklch(0.75 0.15 75);      /* amber */
+  --tactical: oklch(0.75 0.15 75);
   --tactical-foreground: oklch(0.08 0 0);
 
   --sidebar: oklch(0.10 0 0);
@@ -34,8 +64,6 @@
   --sidebar-border: oklch(1 0 0 / 10%);
   --sidebar-ring: oklch(0.55 0 0);
 }
-
-/* No separate .dark block — site is dark-only */
 
 @theme inline {
   --font-body: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;

--- a/styles/theme.css
+++ b/styles/theme.css
@@ -1,139 +1,78 @@
 :root {
-  --radius: 0.625rem;
-  --background: oklch(1 0 0);
-  --foreground: oklch(0.145 0 0);
-  --card: oklch(1 0 0);
-  --card-foreground: oklch(0.145 0 0);
-  --popover: oklch(1 0 0);
-  --popover-foreground: oklch(0.145 0 0);
-  --primary: oklch(0.205 0 0);
-  --primary-foreground: oklch(0.985 0 0);
-  --secondary: oklch(0.97 0 0);
-  --secondary-foreground: oklch(0.205 0 0);
-  --muted: oklch(0.97 0 0);
-  --muted-foreground: oklch(0.556 0 0);
-  --accent: oklch(0.97 0 0);
-  --accent-foreground: oklch(0.205 0 0);
+  --radius: 0.25rem;
+
+  /* Base — dark by default, this site is always dark */
+  --background: oklch(0.08 0 0);         /* near-black */
+  --foreground: oklch(0.92 0 0);         /* off-white */
+  --card: oklch(0.12 0 0);              /* slightly lighter than bg */
+  --card-foreground: oklch(0.92 0 0);
+  --popover: oklch(0.12 0 0);
+  --popover-foreground: oklch(0.92 0 0);
+  --primary: oklch(0.92 0 0);           /* white — main interactive color */
+  --primary-foreground: oklch(0.08 0 0);
+  --secondary: oklch(0.18 0 0);         /* dark gray — secondary surfaces */
+  --secondary-foreground: oklch(0.92 0 0);
+  --muted: oklch(0.18 0 0);
+  --muted-foreground: oklch(0.55 0 0);  /* dim text */
+  --accent: oklch(0.18 0 0);
+  --accent-foreground: oklch(0.92 0 0);
   --destructive: oklch(0.577 0.245 27.325);
-  --border: oklch(0.922 0 0);
-  --input: oklch(0.922 0 0);
-  --ring: oklch(0.708 0 0);
-  --chart-1: oklch(0.646 0.222 41.116);
-  --chart-2: oklch(0.6 0.118 184.704);
-  --chart-3: oklch(0.398 0.07 227.392);
-  --chart-4: oklch(0.828 0.189 84.429);
-  --chart-5: oklch(0.769 0.188 70.08);
-  --sidebar: oklch(0.985 0 0);
-  --sidebar-foreground: oklch(0.145 0 0);
-  --sidebar-primary: oklch(0.205 0 0);
-  --sidebar-primary-foreground: oklch(0.985 0 0);
-  --sidebar-accent: oklch(0.97 0 0);
-  --sidebar-accent-foreground: oklch(0.205 0 0);
-  --sidebar-border: oklch(0.922 0 0);
-  --sidebar-ring: oklch(0.708 0 0);
-
-  /* Brand */
-  --brand-25: #fcfaff;
-  --brand-50: #f9f5ff;
-  --brand-100: #f4ebff;
-  --brand-200: #e9d7fe;
-  --brand-300: #d6bbfb;
-  --brand-400: #b692f6;
-  --brand-500: #9e77ed;
-  --brand-600: #7f56d9;
-  --brand-700: #6941c6;
-  --brand-800: #53389e;
-  --brand-900: #42307d;
-  --brand-950: #2c1c5f;
-}
-
-.dark {
-  --background: oklch(0.145 0 0);
-  --foreground: oklch(0.985 0 0);
-  --card: oklch(0.205 0 0);
-  --card-foreground: oklch(0.985 0 0);
-  --popover: oklch(0.205 0 0);
-  --popover-foreground: oklch(0.985 0 0);
-  --primary: oklch(0.922 0 0);
-  --primary-foreground: oklch(0.205 0 0);
-  --secondary: oklch(0.269 0 0);
-  --secondary-foreground: oklch(0.985 0 0);
-  --muted: oklch(0.269 0 0);
-  --muted-foreground: oklch(0.708 0 0);
-  --accent: oklch(0.269 0 0);
-  --accent-foreground: oklch(0.985 0 0);
-  --destructive: oklch(0.704 0.191 22.216);
   --border: oklch(1 0 0 / 10%);
-  --input: oklch(1 0 0 / 15%);
-  --ring: oklch(0.556 0 0);
-  --chart-1: oklch(0.488 0.243 264.376);
-  --chart-2: oklch(0.696 0.17 162.48);
-  --chart-3: oklch(0.769 0.188 70.08);
-  --chart-4: oklch(0.627 0.265 303.9);
-  --chart-5: oklch(0.645 0.246 16.439);
-  --sidebar: oklch(0.205 0 0);
-  --sidebar-foreground: oklch(0.985 0 0);
-  --sidebar-primary: oklch(0.488 0.243 264.376);
-  --sidebar-primary-foreground: oklch(0.985 0 0);
-  --sidebar-accent: oklch(0.269 0 0);
-  --sidebar-accent-foreground: oklch(0.985 0 0);
+  --input: oklch(1 0 0 / 12%);
+  --ring: oklch(0.55 0 0);
+
+  /* Tactical accent — amber, swap this out when palette is decided */
+  --tactical: oklch(0.75 0.15 75);      /* amber */
+  --tactical-foreground: oklch(0.08 0 0);
+
+  --sidebar: oklch(0.10 0 0);
+  --sidebar-foreground: oklch(0.92 0 0);
+  --sidebar-primary: oklch(0.92 0 0);
+  --sidebar-primary-foreground: oklch(0.08 0 0);
+  --sidebar-accent: oklch(0.18 0 0);
+  --sidebar-accent-foreground: oklch(0.92 0 0);
   --sidebar-border: oklch(1 0 0 / 10%);
-  --sidebar-ring: oklch(0.556 0 0);
+  --sidebar-ring: oklch(0.55 0 0);
 }
+
+/* No separate .dark block — site is dark-only */
 
 @theme inline {
-  --font-body:
-    "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  --font-body: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  --font-sans: var(--font-geist-sans);
+  --font-mono: var(--font-geist-mono);
 
   --color-background: var(--background);
   --color-foreground: var(--foreground);
-  --font-sans: var(--font-geist-sans);
-  --font-mono: var(--font-geist-mono);
-  --color-sidebar-ring: var(--sidebar-ring);
-  --color-sidebar-border: var(--sidebar-border);
-  --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
-  --color-sidebar-accent: var(--sidebar-accent);
-  --color-sidebar-primary-foreground: var(--sidebar-primary-foreground);
-  --color-sidebar-primary: var(--sidebar-primary);
-  --color-sidebar-foreground: var(--sidebar-foreground);
-  --color-sidebar: var(--sidebar);
-  --color-chart-5: var(--chart-5);
-  --color-chart-4: var(--chart-4);
-  --color-chart-3: var(--chart-3);
-  --color-chart-2: var(--chart-2);
-  --color-chart-1: var(--chart-1);
-  --color-ring: var(--ring);
-  --color-input: var(--input);
-  --color-border: var(--border);
-  --color-destructive: var(--destructive);
-  --color-accent-foreground: var(--accent-foreground);
-  --color-accent: var(--accent);
-  --color-muted-foreground: var(--muted-foreground);
-  --color-muted: var(--muted);
-  --color-secondary-foreground: var(--secondary-foreground);
-  --color-secondary: var(--secondary);
-  --color-primary-foreground: var(--primary-foreground);
-  --color-primary: var(--primary);
-  --color-popover-foreground: var(--popover-foreground);
-  --color-popover: var(--popover);
-  --color-card-foreground: var(--card-foreground);
   --color-card: var(--card);
-  --radius-sm: calc(var(--radius) - 4px);
-  --radius-md: calc(var(--radius) - 2px);
-  --radius-lg: var(--radius);
-  --radius-xl: calc(var(--radius) + 4px);
+  --color-card-foreground: var(--card-foreground);
+  --color-popover: var(--popover);
+  --color-popover-foreground: var(--popover-foreground);
+  --color-primary: var(--primary);
+  --color-primary-foreground: var(--primary-foreground);
+  --color-secondary: var(--secondary);
+  --color-secondary-foreground: var(--secondary-foreground);
+  --color-muted: var(--muted);
+  --color-muted-foreground: var(--muted-foreground);
+  --color-accent: var(--accent);
+  --color-accent-foreground: var(--accent-foreground);
+  --color-destructive: var(--destructive);
+  --color-border: var(--border);
+  --color-input: var(--input);
+  --color-ring: var(--ring);
+  --color-tactical: var(--tactical);
+  --color-tactical-foreground: var(--tactical-foreground);
+  --color-sidebar: var(--sidebar);
+  --color-sidebar-foreground: var(--sidebar-foreground);
+  --color-sidebar-primary: var(--sidebar-primary);
+  --color-sidebar-primary-foreground: var(--sidebar-primary-foreground);
+  --color-sidebar-accent: var(--sidebar-accent);
+  --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
+  --color-sidebar-border: var(--sidebar-border);
+  --color-sidebar-ring: var(--sidebar-ring);
 
-  /* Brand */
-  --color-brand-25: var(--brand-25);
-  --color-brand-50: var(--brand-50);
-  --color-brand-100: var(--brand-100);
-  --color-brand-200: var(--brand-200);
-  --color-brand-300: var(--brand-300);
-  --color-brand-400: var(--brand-400);
-  --color-brand-500: var(--brand-500);
-  --color-brand-600: var(--brand-600);
-  --color-brand-700: var(--brand-700);
-  --color-brand-800: var(--brand-800);
-  --color-brand-900: var(--brand-900);
-  --color-brand-950: var(--brand-950);
+  --radius-sm: calc(var(--radius) - 2px);
+  --radius-md: var(--radius);
+  --radius-lg: calc(var(--radius) + 4px);
+  --radius-xl: calc(var(--radius) + 8px);
 }


### PR DESCRIPTION
## Summary
- Replaces default purple/light starter theme with a dark military palette (near-black bg, off-white text, amber tactical accent)
- Removes the light/dark toggle — site is dark-only, enforced via `forcedTheme="dark"` in next-themes
- Tactical accent color (`--tactical`) is amber for now, easy to swap when final palette is decided
- Border radius tightened to `0.25rem` for a sharper, less rounded look

Closes #1

## Test plan
- [ ] Site loads with dark background on first visit (no flash of white)
- [ ] No TypeScript errors (`pnpm exec tsc --noEmit`)
- [ ] Theme toggle is gone from the UI