### PR TITLE
feat: universal PageContainer and sticky footer fix

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -21,7 +21,7 @@ export default function RootLayout({
         <Providers>
           <div className="grid min-h-[100dvh] grid-rows-[auto_1fr_auto]">
             <Header />
-            <main>{children}</main>
+            <main className="flex flex-col">{children}</main>
             <Footer />
           </div>
         </Providers>

--- a/app/newbie/milsim-west/before-you-go/page.tsx
+++ b/app/newbie/milsim-west/before-you-go/page.tsx
@@ -1,0 +1,16 @@
+import Link from "next/link";
+import { ChevronLeft } from "lucide-react";
+import PageContainer from "@/components/layout/page-container";
+
+export default function Page() {
+  return (
+    <PageContainer>
+      <Link href="/newbie/milsim-west" className="mb-8 inline-flex items-center gap-1.5 font-mono text-xs tracking-widest uppercase text-muted-foreground transition-colors hover:text-tactical">
+        <ChevronLeft size={14} /> BACK TO MILSIM WEST
+      </Link>
+      <p className="font-mono text-xs tracking-[0.3em] uppercase text-tactical mb-3">// 01</p>
+      <h1 className="font-mono text-3xl font-bold text-foreground">BEFORE YOU GO</h1>
+      <p className="mt-4 text-sm text-muted-foreground">Content coming soon.</p>
+    </PageContainer>
+  );
+}

--- a/app/newbie/milsim-west/factions/page.tsx
+++ b/app/newbie/milsim-west/factions/page.tsx
@@ -1,0 +1,16 @@
+import Link from "next/link";
+import { ChevronLeft } from "lucide-react";
+import PageContainer from "@/components/layout/page-container";
+
+export default function Page() {
+  return (
+    <PageContainer>
+      <Link href="/newbie/milsim-west" className="mb-8 inline-flex items-center gap-1.5 font-mono text-xs tracking-widest uppercase text-muted-foreground transition-colors hover:text-tactical">
+        <ChevronLeft size={14} /> BACK TO MILSIM WEST
+      </Link>
+      <p className="font-mono text-xs tracking-[0.3em] uppercase text-tactical mb-3">// 06</p>
+      <h1 className="font-mono text-3xl font-bold text-foreground">FACTIONS</h1>
+      <p className="mt-4 text-sm text-muted-foreground">Content coming soon.</p>
+    </PageContainer>
+  );
+}

--- a/app/newbie/milsim-west/gear/page.tsx
+++ b/app/newbie/milsim-west/gear/page.tsx
@@ -1,0 +1,16 @@
+import Link from "next/link";
+import { ChevronLeft } from "lucide-react";
+import PageContainer from "@/components/layout/page-container";
+
+export default function Page() {
+  return (
+    <PageContainer>
+      <Link href="/newbie/milsim-west" className="mb-8 inline-flex items-center gap-1.5 font-mono text-xs tracking-widest uppercase text-muted-foreground transition-colors hover:text-tactical">
+        <ChevronLeft size={14} /> BACK TO MILSIM WEST
+      </Link>
+      <p className="font-mono text-xs tracking-[0.3em] uppercase text-tactical mb-3">// 02</p>
+      <h1 className="font-mono text-3xl font-bold text-foreground">GEAR GUIDE</h1>
+      <p className="mt-4 text-sm text-muted-foreground">Content coming soon.</p>
+    </PageContainer>
+  );
+}

--- a/app/newbie/milsim-west/lingo/page.tsx
+++ b/app/newbie/milsim-west/lingo/page.tsx
@@ -1,0 +1,16 @@
+import Link from "next/link";
+import { ChevronLeft } from "lucide-react";
+import PageContainer from "@/components/layout/page-container";
+
+export default function Page() {
+  return (
+    <PageContainer>
+      <Link href="/newbie/milsim-west" className="mb-8 inline-flex items-center gap-1.5 font-mono text-xs tracking-widest uppercase text-muted-foreground transition-colors hover:text-tactical">
+        <ChevronLeft size={14} /> BACK TO MILSIM WEST
+      </Link>
+      <p className="font-mono text-xs tracking-[0.3em] uppercase text-tactical mb-3">// 04</p>
+      <h1 className="font-mono text-3xl font-bold text-foreground">PLATOON LINGO</h1>
+      <p className="mt-4 text-sm text-muted-foreground">Content coming soon.</p>
+    </PageContainer>
+  );
+}

--- a/app/newbie/milsim-west/page.tsx
+++ b/app/newbie/milsim-west/page.tsx
@@ -1,0 +1,105 @@
+import Link from "next/link";
+import { ChevronRight, ChevronLeft } from "lucide-react";
+import PageContainer from "@/components/layout/page-container";
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Milsim West Guide — MILSIM",
+  description: "The complete first-timer guide for Milsim West events.",
+};
+
+const SECTIONS = [
+  {
+    slug: "before-you-go",
+    number: "01",
+    emoji: "📋",
+    title: "Before You Go",
+    description: "Waiver, check-in time, what to pack the day of. Don't show up unprepared.",
+  },
+  {
+    slug: "gear",
+    number: "02",
+    emoji: "🎒",
+    title: "Gear Guide",
+    description: "What you actually need for a 40–72 hr op. Budget picks included.",
+  },
+  {
+    slug: "tactics",
+    number: "03",
+    emoji: "🎯",
+    title: "Tactics 101",
+    description: "Basic movement and cover so you don't get your squad wiped in hour one.",
+  },
+  {
+    slug: "lingo",
+    number: "04",
+    emoji: "📻",
+    title: "Platoon Lingo",
+    description: "Commands your PL will yell. Learn them before the op, not during.",
+  },
+  {
+    slug: "tacsop",
+    number: "05",
+    emoji: "📖",
+    title: "TACSOP Simplified",
+    description: "MSW rules cut down to what actually matters. No walls of text.",
+  },
+  {
+    slug: "factions",
+    number: "06",
+    emoji: "🪖",
+    title: "Factions",
+    description: "NATO, RUFOR, and who else is on the field. Know your side before you show up.",
+  },
+];
+
+export default function MilsimWestPage() {
+  return (
+    <PageContainer>
+      <Link
+        href="/newbie"
+        className="mb-8 inline-flex items-center gap-1.5 font-mono text-xs tracking-widest uppercase text-muted-foreground transition-colors hover:text-tactical"
+      >
+        <ChevronLeft size={14} />
+        BACK TO NEWBIE GUIDE
+      </Link>
+
+      <p className="mb-3 font-mono text-xs tracking-[0.3em] uppercase text-tactical">
+        // OPERATION BRIEFING
+      </p>
+      <h1 className="font-mono text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
+        MILSIM WEST
+      </h1>
+      <p className="mt-4 max-w-xl text-sm leading-relaxed text-muted-foreground">
+        MSW runs some of the most immersive ops in the country. Long hours, real
+        friction, and zero handholding. Pick a section and get ready.
+      </p>
+
+      <div className="mt-12 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        {SECTIONS.map((section) => (
+          <Link
+            key={section.slug}
+            href={`/newbie/milsim-west/${section.slug}`}
+            className="group relative flex flex-col gap-4 border border-border bg-card p-5 transition-all hover:border-tactical hover:-translate-y-0.5 hover:shadow-lg"
+          >
+            <span className="text-4xl leading-none">{section.emoji}</span>
+            <span className="absolute right-4 top-4 font-mono text-xs text-muted-foreground/40">
+              {section.number}
+            </span>
+            <div>
+              <h2 className="font-mono text-base font-bold text-foreground transition-colors group-hover:text-tactical">
+                {section.title}
+              </h2>
+              <p className="mt-1.5 text-sm leading-relaxed text-muted-foreground">
+                {section.description}
+              </p>
+            </div>
+            <div className="mt-auto flex items-center gap-1 font-mono text-xs tracking-widest uppercase text-tactical opacity-0 transition-opacity group-hover:opacity-100">
+              OPEN <ChevronRight size={12} />
+            </div>
+          </Link>
+        ))}
+      </div>
+    </PageContainer>
+  );
+}

--- a/app/newbie/milsim-west/tacsop/page.tsx
+++ b/app/newbie/milsim-west/tacsop/page.tsx
@@ -1,0 +1,16 @@
+import Link from "next/link";
+import { ChevronLeft } from "lucide-react";
+import PageContainer from "@/components/layout/page-container";
+
+export default function Page() {
+  return (
+    <PageContainer>
+      <Link href="/newbie/milsim-west" className="mb-8 inline-flex items-center gap-1.5 font-mono text-xs tracking-widest uppercase text-muted-foreground transition-colors hover:text-tactical">
+        <ChevronLeft size={14} /> BACK TO MILSIM WEST
+      </Link>
+      <p className="font-mono text-xs tracking-[0.3em] uppercase text-tactical mb-3">// 05</p>
+      <h1 className="font-mono text-3xl font-bold text-foreground">TACSOP SIMPLIFIED</h1>
+      <p className="mt-4 text-sm text-muted-foreground">Content coming soon.</p>
+    </PageContainer>
+  );
+}

--- a/app/newbie/milsim-west/tactics/page.tsx
+++ b/app/newbie/milsim-west/tactics/page.tsx
@@ -1,0 +1,16 @@
+import Link from "next/link";
+import { ChevronLeft } from "lucide-react";
+import PageContainer from "@/components/layout/page-container";
+
+export default function Page() {
+  return (
+    <PageContainer>
+      <Link href="/newbie/milsim-west" className="mb-8 inline-flex items-center gap-1.5 font-mono text-xs tracking-widest uppercase text-muted-foreground transition-colors hover:text-tactical">
+        <ChevronLeft size={14} /> BACK TO MILSIM WEST
+      </Link>
+      <p className="font-mono text-xs tracking-[0.3em] uppercase text-tactical mb-3">// 03</p>
+      <h1 className="font-mono text-3xl font-bold text-foreground">TACTICS 101</h1>
+      <p className="mt-4 text-sm text-muted-foreground">Content coming soon.</p>
+    </PageContainer>
+  );
+}

--- a/app/newbie/page.tsx
+++ b/app/newbie/page.tsx
@@ -1,0 +1,104 @@
+import Link from "next/link";
+import { ChevronRight, ChevronLeft, Lock } from "lucide-react";
+import PageContainer from "@/components/layout/page-container";
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Newbie Guide — MILSIM",
+  description: "Everything a first-timer needs before stepping onto the field.",
+};
+
+const ORGS = [
+  {
+    slug: "milsim-west",
+    name: "Milsim West",
+    description:
+      "The full breakdown for MSW events — gear, tactics, lingo, TACSOP simplified, and everything to do before you show up.",
+    available: true,
+    tag: "ATTENDED",
+  },
+  {
+    slug: "american-milsim",
+    name: "American Milsim",
+    description:
+      "Haven't attended yet. Guide coming once I've got boots-on-ground experience to back it up.",
+    available: false,
+    tag: "COMING SOON",
+  },
+];
+
+export default function NewbiePage() {
+  return (
+    <PageContainer>
+      <Link
+        href="/"
+        className="mb-8 inline-flex items-center gap-1.5 font-mono text-xs tracking-widest uppercase text-muted-foreground transition-colors hover:text-tactical"
+      >
+        <ChevronLeft size={14} />
+        BACK TO HOME
+      </Link>
+
+      <p className="mb-3 font-mono text-xs tracking-[0.3em] uppercase text-tactical">
+        // NEWBIE GUIDE
+      </p>
+      <h1 className="font-mono text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
+        PICK YOUR OP
+      </h1>
+      <p className="mt-4 max-w-xl text-sm leading-relaxed text-muted-foreground">
+        Different orgs run different ops. Each one has its own rules, culture,
+        and gear requirements. Pick the one you&apos;re attending and get the
+        full breakdown.
+      </p>
+
+      <div className="mt-12 grid gap-4 sm:grid-cols-2">
+        {ORGS.map((org) =>
+          org.available ? (
+            <Link
+              key={org.slug}
+              href={`/newbie/${org.slug}`}
+              className="group relative flex flex-col justify-between border border-border bg-card p-6 transition-colors hover:border-tactical"
+            >
+              <div>
+                <div className="mb-4 flex items-center justify-between">
+                  <span className="font-mono text-xs tracking-widest uppercase text-tactical">
+                    {org.tag}
+                  </span>
+                  <ChevronRight
+                    size={16}
+                    className="text-muted-foreground transition-transform group-hover:translate-x-1 group-hover:text-tactical"
+                  />
+                </div>
+                <h2 className="font-mono text-xl font-bold text-foreground">
+                  {org.name}
+                </h2>
+                <p className="mt-2 text-sm leading-relaxed text-muted-foreground">
+                  {org.description}
+                </p>
+              </div>
+            </Link>
+          ) : (
+            <div
+              key={org.slug}
+              className="relative flex flex-col justify-between border border-border bg-card p-6 opacity-50"
+            >
+              <div>
+                <div className="mb-4 flex items-center justify-between">
+                  <span className="font-mono text-xs tracking-widest uppercase text-muted-foreground">
+                    {org.tag}
+                  </span>
+                  <Lock size={16} className="text-muted-foreground" />
+                </div>
+                <h2 className="font-mono text-xl font-bold text-foreground">
+                  {org.name}
+                </h2>
+                <p className="mt-2 text-sm leading-relaxed text-muted-foreground">
+                  {org.description}
+                </p>
+              </div>
+            </div>
+          )
+        )}
+      </div>
+    </PageContainer>
+  );
+}

--- a/components/layout/hero.tsx
+++ b/components/layout/hero.tsx
@@ -2,7 +2,7 @@ import Link from "next/link";
 
 export default function Hero() {
   return (
-    <section className="relative flex min-h-[90vh] flex-col items-center justify-center overflow-hidden bg-background px-4 text-center">
+    <section className="relative flex min-h-[calc(100dvh-3.5rem)] flex-col items-center justify-center overflow-hidden bg-background px-4 text-center">
       {/* Grid overlay for tactical feel */}
       <div
         aria-hidden

--- a/components/layout/page-container.tsx
+++ b/components/layout/page-container.tsx
@@ -7,7 +7,7 @@ interface PageContainerProps {
 
 export default function PageContainer({ children, className }: PageContainerProps) {
   return (
-    <div className={cn("mx-auto w-full max-w-5xl flex-1 px-4 py-16 sm:px-6", className)}>
+    <div className={cn("mx-auto w-full max-w-5xl flex-1 px-4 pt-16 pb-32 sm:px-6 min-h-[80vh]", className)}>
       {children}
     </div>
   );

--- a/components/layout/page-container.tsx
+++ b/components/layout/page-container.tsx
@@ -1,0 +1,14 @@
+import { cn } from "@/lib/utils";
+
+interface PageContainerProps {
+  children: React.ReactNode;
+  className?: string;
+}
+
+export default function PageContainer({ children, className }: PageContainerProps) {
+  return (
+    <div className={cn("mx-auto w-full max-w-5xl flex-1 px-4 py-16 sm:px-6", className)}>
+      {children}
+    </div>
+  );
+}

--- a/components/layout/page-container.tsx
+++ b/components/layout/page-container.tsx
@@ -7,7 +7,7 @@ interface PageContainerProps {
 
 export default function PageContainer({ children, className }: PageContainerProps) {
   return (
-    <div className={cn("mx-auto w-full max-w-5xl flex-1 px-4 pt-16 pb-32 sm:px-6 min-h-[80vh]", className)}>
+    <div className={cn("mx-auto w-full max-w-5xl flex-1 px-4 pt-16 pb-40 sm:px-6 min-h-[calc(100dvh-3.5rem)]", className)}>
       {children}
     </div>
   );


### PR DESCRIPTION
## Summary
- Added `PageContainer` component — every page uses it for consistent `max-w-5xl`, `px-4 sm:px-6`, and `py-16` spacing
- Fixed footer floating up on short pages by adding `flex flex-col` to `<main>` so it properly fills the `1fr` grid row
- Applied `PageContainer` to all newbie pages with consistent back buttons

Closes #5

## Test plan
- [ ] Footer stays at the bottom on short pages (e.g. stub pages)
- [ ] Footer scrolls naturally on long pages
- [ ] All pages have consistent left/right alignment and padding