### PR TITLE
feat: Before You Go page — full MSW content

### DIFF
--- a/app/newbie/milsim-west/before-you-go/page.tsx
+++ b/app/newbie/milsim-west/before-you-go/page.tsx
@@ -1,69 +1,24 @@
 import Link from "next/link";
-import { ChevronLeft, CheckCircle2, Clock, MapPin, FileText, ShieldCheck, AlertTriangle } from "lucide-react";
+import { ChevronLeft, ChevronRight, AlertTriangle, Clock, Mail, MapPin, CheckCircle2, ShieldCheck } from "lucide-react";
 import PageContainer from "@/components/layout/page-container";
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
   title: "Before You Go — Milsim West",
-  description: "Everything you need to do and bring before showing up to a Milsim West event.",
+  description: "Everything you need before arriving at a Milsim West event.",
 };
 
-const CHECKLIST = [
-  "Printed & signed waiver (physical copy — no phone)",
-  "Valid government-issued ID",
-  "Faction-correct uniform (NATO or RUFOR — check your ticket)",
-  "Eye protection (full seal, ANSI rated)",
-  "Face protection (lower face mesh or goggles with coverage)",
-  "Airsoft replica + magazines",
-  "BBs (enough for 40–72 hrs — bring more than you think)",
-  "Sleeping gear (sleeping bag, tent or tarp, sleeping pad)",
-  "Food & water for the full op (MREs, snacks, hydration pack)",
-  "Extra batteries or charger for your replica",
-  "Radio + extra batteries",
-  "First aid kit / personal medications",
+const ARRIVAL_CHECKLIST = [
+  "Printed deployment orders (sent via email — keep an eye on your inbox)",
+  "Valid government-issued photo ID",
+  "All red-highlighted gear from the TACSOP packing list",
+  "Airsoft replica + magazines + BBs",
+  "Radio + batteries",
+  "Sleeping gear (sleeping bag, pad, tent or tarp)",
+  "Food & water for the full op",
+  "Red light flashlight (no white lights at night)",
   "Cash (some vendors on site)",
-  "Red light flashlight (white light = you get lit up at night)",
-];
-
-const SECTIONS = [
-  {
-    Icon: Clock,
-    title: "When to Arrive",
-    content: [
-      "Check-in usually opens Friday afternoon and closes in the evening — don't show up 20 minutes before it closes.",
-      "Aim to arrive at least 1–2 hours before check-in closes. You'll need time to set up camp, get through the line, pass chrono, and get your briefing.",
-      "Late arrivals miss the opening briefing and start the op already behind. Don't be that person.",
-    ],
-  },
-  {
-    Icon: FileText,
-    title: "Your Waiver",
-    content: [
-      "Print it. Sign it. Bring the physical copy. They will not accept it on your phone.",
-      "Download the MSW waiver from the official Milsim West website before you leave. If you forget it, you're not getting in.",
-      "If you're under 18, a parent or guardian signature is required on the waiver.",
-    ],
-  },
-  {
-    Icon: MapPin,
-    title: "Check-In Process",
-    content: [
-      "When you arrive, go straight to check-in. Don't set up camp first.",
-      "You'll hand over your waiver, show your ID, and get your wristband and faction assignment confirmed.",
-      "After check-in, your replica goes through chronograph testing. If your gun shoots over the event's FPS limit, you won't be able to use it — know your limits before you show up.",
-      "After chrono, you'll get a briefing on the AO (area of operations), rules, and your first objectives.",
-    ],
-  },
-  {
-    Icon: ShieldCheck,
-    title: "Chrono Limits",
-    content: [
-      "AEGs (automatic electric guns): typically 400 FPS with 0.20g BBs.",
-      "DMRs (semi-auto only): typically up to 450–500 FPS with a minimum engagement distance.",
-      "Bolt-action sniper rifles: up to 550 FPS with a minimum engagement distance.",
-      "Check the specific event page for exact limits — they can vary per op.",
-    ],
-  },
+  "Personal medications",
 ];
 
 export default function BeforeYouGoPage() {
@@ -78,51 +33,144 @@ export default function BeforeYouGoPage() {
       </Link>
 
       <p className="mb-3 font-mono text-xs tracking-[0.3em] uppercase text-tactical">// 01</p>
-      <h1 className="font-mono text-3xl font-bold text-foreground sm:text-4xl">
-        BEFORE YOU GO
-      </h1>
+      <h1 className="font-mono text-3xl font-bold text-foreground sm:text-4xl">BEFORE YOU GO</h1>
       <p className="mt-4 max-w-xl text-sm leading-relaxed text-muted-foreground">
         Most newbies show up unprepared and spend the first few hours scrambling.
         Read this before you leave the house.
       </p>
 
-      {/* Warning banner */}
+      {/* Critical warning */}
       <div className="mt-8 flex items-start gap-3 border border-tactical/40 bg-tactical/5 p-4">
         <AlertTriangle size={16} className="mt-0.5 shrink-0 text-tactical" />
         <p className="text-sm text-muted-foreground">
-          <span className="font-bold text-foreground">No printed waiver = no entry.</span>{" "}
-          This is the #1 reason new players get turned away at the gate. Print it before you leave.
+          <span className="font-bold text-foreground">No deployment orders = no entry.</span>{" "}
+          MSW will not have your orders on hand. If you don't print them and bring them, you are not getting in — no exceptions.
         </p>
       </div>
 
-      {/* Info sections */}
-      <div className="mt-12 flex flex-col gap-8">
-        {SECTIONS.map(({ Icon, title, content }) => (
-          <div key={title} className="border border-border bg-card p-6">
-            <div className="mb-4 flex items-center gap-3">
-              <Icon size={18} className="text-tactical shrink-0" />
-              <h2 className="font-mono text-sm font-bold tracking-widest uppercase text-foreground">
-                {title}
-              </h2>
-            </div>
-            <ul className="flex flex-col gap-2">
-              {content.map((item, i) => (
-                <li key={i} className="text-sm leading-relaxed text-muted-foreground">
-                  {item}
+      <div className="mt-12 flex flex-col gap-6">
+
+        {/* Deployment Orders */}
+        <div className="border border-border bg-card p-6">
+          <div className="mb-4 flex items-center gap-3">
+            <Mail size={18} className="shrink-0 text-tactical" />
+            <h2 className="font-mono text-sm font-bold tracking-widest uppercase text-foreground">
+              Deployment Orders
+            </h2>
+          </div>
+          <div className="flex flex-col gap-3 text-sm leading-relaxed text-muted-foreground">
+            <p>
+              MSW will send your deployment orders to the email you used to buy your ticket — sometimes weeks in advance, sometimes the day before. <span className="font-semibold text-foreground">Check your email and print them the moment they arrive.</span>
+            </p>
+            <p>
+              Your orders contain your faction assignment, rules of engagement, and a gear checklist. All items highlighted in red on that list are <span className="font-semibold text-foreground">mandatory</span> — show up missing any of them and you will be turned away and told not to come back until you have everything.
+            </p>
+            <p>
+              Items in black are recommended but optional. Don't stress those — focus on the red ones first.
+            </p>
+            <p>
+              During the game, any leader or cadre can stop you at any time and ask to see your papers. If your gear check isn't signed off, you're out of the game — mid-op. Keep your orders on you.
+            </p>
+          </div>
+        </div>
+
+        {/* Arrival Time */}
+        <div className="border border-border bg-card p-6">
+          <div className="mb-4 flex items-center gap-3">
+            <Clock size={18} className="shrink-0 text-tactical" />
+            <h2 className="font-mono text-sm font-bold tracking-widest uppercase text-foreground">
+              When to Arrive
+            </h2>
+          </div>
+          <div className="flex flex-col gap-3 text-sm leading-relaxed text-muted-foreground">
+            <p>
+              In-processing opens at <span className="font-semibold text-foreground">1400 (2:00 PM)</span> and closes at <span className="font-semibold text-foreground">1800 (6:00 PM)</span>.{" "}
+              <span className="font-semibold text-foreground">Do not arrive before 1400</span> — the venue is private property.
+            </p>
+            <p>
+              The game officially kicks off around <span className="font-semibold text-foreground">2200–0000 (10 PM–midnight)</span>, so you'll have several hours to get settled after check-in.
+            </p>
+            <p className="rounded border border-border bg-background px-3 py-2">
+              <span className="font-semibold text-foreground">First timer tip:</span> Arrive early — around 1400–1500. Use the extra time to set up your sleeping area, eat, hydrate, and mentally prep before the game starts. You don't want to be rushing through check-in and setting up camp in the dark right before op start.
+            </p>
+          </div>
+        </div>
+
+        {/* Check-in Process */}
+        <div className="border border-border bg-card p-6">
+          <div className="mb-4 flex items-center gap-3">
+            <MapPin size={18} className="shrink-0 text-tactical" />
+            <h2 className="font-mono text-sm font-bold tracking-widest uppercase text-foreground">
+              Check-In Process
+            </h2>
+          </div>
+          <div className="flex flex-col gap-4 text-sm leading-relaxed text-muted-foreground">
+            <p>
+              Before the event, join the <span className="font-semibold text-foreground">MSW Facebook group for your faction</span>. Your platoon assignment will be posted there — know it before you arrive.
+            </p>
+
+            <ol className="flex flex-col gap-3">
+              {[
+                { step: "01", text: "Arrive and go directly to your assigned platoon area — don't set up camp first." },
+                { step: "02", text: "Lay out your gear. A cadre (the admin or faction leader) will do your back check-in — they inspect all red-highlighted items from your orders and initial each one off." },
+                { step: "03", text: "Once your gear check is signed off, head to chrono. Your replica must pass the FPS check to play." },
+                { step: "04", text: "If you're running a BFA (Blank Firing Adapter), let the cadre know at back check-in — there's a separate process for blanks and they'll point you in the right direction." },
+              ].map(({ step, text }) => (
+                <li key={step} className="flex items-start gap-3">
+                  <span className="font-mono text-xs font-bold text-tactical shrink-0 mt-0.5">{step}</span>
+                  <span>{text}</span>
                 </li>
               ))}
-            </ul>
+            </ol>
+
+            {/* Links to other sections */}
+            <div className="mt-2 flex flex-wrap gap-3">
+              <Link
+                href="/newbie/milsim-west/gear"
+                className="inline-flex items-center gap-1 font-mono text-xs tracking-widest uppercase text-tactical hover:underline"
+              >
+                SEE GEAR GUIDE <ChevronRight size={11} />
+              </Link>
+              <Link
+                href="/newbie/milsim-west/factions"
+                className="inline-flex items-center gap-1 font-mono text-xs tracking-widest uppercase text-tactical hover:underline"
+              >
+                SEE FACTIONS <ChevronRight size={11} />
+              </Link>
+            </div>
           </div>
-        ))}
+        </div>
+
+        {/* Chrono */}
+        <div className="border border-border bg-card p-6">
+          <div className="mb-4 flex items-center gap-3">
+            <ShieldCheck size={18} className="shrink-0 text-tactical" />
+            <h2 className="font-mono text-sm font-bold tracking-widest uppercase text-foreground">
+              Chrono
+            </h2>
+          </div>
+          <div className="flex flex-col gap-3 text-sm leading-relaxed text-muted-foreground">
+            <p>
+              MSW does not allow DMRs. You're running a standard AEG. Check the specific event's orders for the exact FPS limit — it's typically around <span className="font-semibold text-foreground">400 FPS with 0.20g BBs</span>.
+            </p>
+            <p>
+              If your replica shoots over the limit it doesn't play — period. Know your gun before you show up.
+            </p>
+          </div>
+        </div>
       </div>
 
-      {/* Checklist */}
+      {/* Packing checklist */}
       <div className="mt-12">
-        <h2 className="mb-6 font-mono text-sm font-bold tracking-widest uppercase text-foreground">
-          // PACKING CHECKLIST
+        <h2 className="mb-2 font-mono text-sm font-bold tracking-widest uppercase text-foreground">
+          // DAY-OF CHECKLIST
         </h2>
+        <p className="mb-6 text-sm text-muted-foreground">
+          The essentials for arriving. For faction-specific gear and full loadout see the{" "}
+          <Link href="/newbie/milsim-west/gear" className="text-tactical hover:underline">Gear Guide</Link>.
+        </p>
         <div className="grid gap-2 sm:grid-cols-2">
-          {CHECKLIST.map((item) => (
+          {ARRIVAL_CHECKLIST.map((item) => (
             <div key={item} className="flex items-start gap-3 border border-border bg-card p-3">
               <CheckCircle2 size={15} className="mt-0.5 shrink-0 text-tactical" />
               <span className="text-sm text-muted-foreground">{item}</span>

--- a/app/newbie/milsim-west/before-you-go/page.tsx
+++ b/app/newbie/milsim-west/before-you-go/page.tsx
@@ -11,10 +11,10 @@ export const metadata: Metadata = {
 const ARRIVAL_CHECKLIST = [
   "Printed deployment orders (in a ziplock bag — keep them dry)",
   "Valid government-issued photo ID",
-  "All red-highlighted gear from your deployment orders packing list",
-  "Airsoft replica + magazines (no BBs — they are provided at the event)",
+  "All red-highlighted gear from your deployment orders",
+  "Airsoft replica + magazines (no BBs — provided at the event)",
   "Red light flashlight (no white lights at night)",
-  "Cash (~$50 for food, patches, etc.)",
+  "Cash (~$50 for patches and miscellaneous)",
   "Personal medications",
 ];
 
@@ -61,11 +61,10 @@ export default function BeforeYouGoPage() {
               <span className="font-semibold text-foreground">Check your email and print them the moment they arrive.</span>
             </p>
             <p>
-              Your orders contain your faction assignment, rules of engagement, and a gear checklist. All items highlighted in red on that list are{" "}
-              <span className="font-semibold text-foreground">mandatory</span> — show up missing any of them and you will be turned away. Items in black are recommended but optional.
+              Your orders are a printed document with the event name, address, and a checklist at the bottom. That checklist is what the cadre uses during back check-in — they go through each item and initial it off. You need every red item on that list checked and signed before you can play.
             </p>
             <p>
-              During the game, any leader or cadre can stop you at any time and ask to see your papers. If your gear check isn't signed off you're out of the game mid-op. Keep your orders on you at all times.
+              During the game, any leader or cadre can stop you at any time and ask to see your orders. If your check isn't signed off or your paper is gone, you're out mid-op. Keep them on you at all times.
             </p>
             <div className="mt-1 rounded border border-border bg-background px-3 py-2">
               <span className="font-semibold text-foreground">First timer tip:</span> Put your deployment orders in a ziplock sandwich bag before you leave. Rain, sweat, river crossings — anything can destroy paper out in the field. If a leader asks for your orders and the paper is destroyed, you're getting kicked. Keep them dry.
@@ -73,30 +72,7 @@ export default function BeforeYouGoPage() {
           </div>
         </div>
 
-        {/* Arrival Time */}
-        <div className="border border-border bg-card p-6">
-          <div className="mb-4 flex items-center gap-3">
-            <Clock size={18} className="shrink-0 text-tactical" />
-            <h2 className="font-mono text-sm font-bold tracking-widest uppercase text-foreground">
-              When to Arrive
-            </h2>
-          </div>
-          <div className="flex flex-col gap-3 text-sm leading-relaxed text-muted-foreground">
-            <p>
-              In-processing opens at <span className="font-semibold text-foreground">1400 (2:00 PM)</span> and closes at{" "}
-              <span className="font-semibold text-foreground">1800 (6:00 PM)</span>.{" "}
-              <span className="font-semibold text-foreground">Do not arrive before 1400</span> — the venue is private property.
-            </p>
-            <p>
-              The game officially kicks off around <span className="font-semibold text-foreground">2200–0000 (10 PM – midnight)</span>, so you'll have several hours after check-in before it starts. You're going to be up all night — if you think about it, you're essentially awake for two full days straight.
-            </p>
-            <div className="mt-1 rounded border border-border bg-background px-3 py-2">
-              <span className="font-semibold text-foreground">First timer tip:</span> Arrive early around 1400–1500. Use that extra time to talk to the people in your platoon, eat something, hydrate, and mentally prepare. Just relax — because once the game starts, that's it.
-            </div>
-          </div>
-        </div>
-
-        {/* Check-in Process */}
+        {/* Check-in Process — intentionally before When to Arrive */}
         <div className="border border-border bg-card p-6">
           <div className="mb-4 flex items-center gap-3">
             <MapPin size={18} className="shrink-0 text-tactical" />
@@ -108,7 +84,6 @@ export default function BeforeYouGoPage() {
             <p>
               Before the event, join the <span className="font-semibold text-foreground">MSW Facebook group for your faction</span>. Your platoon assignment will be posted there — know it before you arrive.
             </p>
-
             <ol className="flex flex-col gap-3">
               {[
                 {
@@ -117,11 +92,11 @@ export default function BeforeYouGoPage() {
                 },
                 {
                   step: "02",
-                  text: "Find the bag check-in area. There will be a group of people with a cadre calling out items from the packing list — that's where you lay your gear out for inspection, not where you lined up with your platoon.",
+                  text: "Find the bag check-in area. There will be a group of people with a cadre calling out items — that's where you lay your gear out for inspection, not just where you lined up with your platoon.",
                 },
                 {
                   step: "03",
-                  text: "The cadre inspects all red-highlighted items and initials them off on your orders. Once every item is checked, you're cleared to move on.",
+                  text: "The cadre goes through all the red-highlighted items and initials them off on your orders. Once everything is checked, you're cleared.",
                 },
                 {
                   step: "04",
@@ -138,7 +113,6 @@ export default function BeforeYouGoPage() {
                 </li>
               ))}
             </ol>
-
             <div className="mt-2 flex flex-wrap gap-3">
               <Link
                 href="/newbie/milsim-west/gear"
@@ -156,6 +130,32 @@ export default function BeforeYouGoPage() {
           </div>
         </div>
 
+        {/* When to Arrive */}
+        <div className="border border-border bg-card p-6">
+          <div className="mb-4 flex items-center gap-3">
+            <Clock size={18} className="shrink-0 text-tactical" />
+            <h2 className="font-mono text-sm font-bold tracking-widest uppercase text-foreground">
+              When to Arrive
+            </h2>
+          </div>
+          <div className="flex flex-col gap-3 text-sm leading-relaxed text-muted-foreground">
+            <p>
+              In-processing opens at <span className="font-semibold text-foreground">1400 (2:00 PM)</span> and closes at{" "}
+              <span className="font-semibold text-foreground">1800 (6:00 PM)</span>.{" "}
+              <span className="font-semibold text-foreground">Do not arrive before 1400</span> — the venue is private property.
+            </p>
+            <p>
+              The game kicks off around <span className="font-semibold text-foreground">2200–0000 (10 PM – midnight)</span>. Be prepared — you could be up all night, which is pretty much a full 24 hours on your feet by the time the game is over.
+            </p>
+            <div className="rounded border border-border bg-background px-3 py-2">
+              <span className="font-semibold text-foreground">First timer tip:</span> Arrive early around 1400–1500. After check-in, eat, hydrate, talk to your platoon — and if there's downtime, take a nap. Seriously. You're going to need it. Alternatively, if you're not far from the venue, arriving a little later gives you more time to rest at home before the long night ahead.
+            </div>
+            <div className="rounded border border-border bg-background px-3 py-2">
+              <span className="font-semibold text-foreground">Bonus tip:</span> Bring a separate water bottle and snacks that are NOT part of your game gear. You'll be on site for several hours before the game even starts — don't burn through your field rations just sitting around waiting. Eat before you go and keep your game food and water sealed for the actual op.
+            </div>
+          </div>
+        </div>
+
         {/* Chrono */}
         <div className="border border-border bg-card p-6">
           <div className="mb-4 flex items-center gap-3">
@@ -166,7 +166,8 @@ export default function BeforeYouGoPage() {
           </div>
           <div className="flex flex-col gap-3 text-sm leading-relaxed text-muted-foreground">
             <p>
-              MSW does not allow DMRs — standard AEGs only. Check your specific event's deployment orders for the exact FPS limit.
+              Standard AEGs follow the same rules as any airsoft field —{" "}
+              <span className="font-semibold text-foreground">under 400 FPS</span>. Check your specific event's orders for the exact limit.
             </p>
             <div className="flex items-start gap-3 rounded border border-tactical/40 bg-tactical/5 px-3 py-2">
               <AlertTriangle size={14} className="mt-0.5 shrink-0 text-tactical" />
@@ -177,6 +178,7 @@ export default function BeforeYouGoPage() {
             </div>
           </div>
         </div>
+
       </div>
 
       {/* Packing checklist */}

--- a/app/newbie/milsim-west/before-you-go/page.tsx
+++ b/app/newbie/milsim-west/before-you-go/page.tsx
@@ -202,7 +202,7 @@ export default function BeforeYouGoPage() {
               ))}
             </ul>
             <div className="mt-1 rounded border border-border bg-background px-3 py-2">
-              <span className="font-semibold text-foreground">Tip:</span> Keep both your deployment orders and medical card in the same ziplock bag and store it in your left chest pocket. If something happens in the field, that's the first place anyone is going to look — make it easy to find fast.
+              <span className="font-semibold text-foreground">Tip:</span> Keep both your deployment orders and medical card in the same ziplock bag and store it in your left shoulder pocket. If something happens in the field, that's the first place anyone is going to look — make it easy to find fast.
             </div>
           </div>
         </div>
@@ -226,6 +226,7 @@ export default function BeforeYouGoPage() {
               {[
                 { label: "Go running", detail: "Be comfortable running 3 miles straight before the event. This op is a physical challenge — your cardio will be tested." },
                 { label: "Train with weight", detail: "Practice walking or running with a weighted vest or your actual gear so your body isn't shocked on game day." },
+                { label: "Practice rucking", detail: "Rucking means moving with your full kit — replica, vest, and a loaded pack on your back. Depending on the event you could ruck anywhere from 2 to 8 miles in a single day. Get comfortable carrying that weight before you show up, not during." },
                 { label: "Break in your boots", detail: "Do not show up in a fresh pair of boots. Wear them on runs and walks beforehand — blisters 10 hours into an op are brutal." },
                 { label: "Get sleep before", detail: "You're going to be up all night. Don't show up already running on empty." },
               ].map(({ label, detail }) => (

--- a/app/newbie/milsim-west/before-you-go/page.tsx
+++ b/app/newbie/milsim-west/before-you-go/page.tsx
@@ -1,16 +1,135 @@
 import Link from "next/link";
-import { ChevronLeft } from "lucide-react";
+import { ChevronLeft, CheckCircle2, Clock, MapPin, FileText, ShieldCheck, AlertTriangle } from "lucide-react";
 import PageContainer from "@/components/layout/page-container";
+import type { Metadata } from "next";
 
-export default function Page() {
+export const metadata: Metadata = {
+  title: "Before You Go — Milsim West",
+  description: "Everything you need to do and bring before showing up to a Milsim West event.",
+};
+
+const CHECKLIST = [
+  "Printed & signed waiver (physical copy — no phone)",
+  "Valid government-issued ID",
+  "Faction-correct uniform (NATO or RUFOR — check your ticket)",
+  "Eye protection (full seal, ANSI rated)",
+  "Face protection (lower face mesh or goggles with coverage)",
+  "Airsoft replica + magazines",
+  "BBs (enough for 40–72 hrs — bring more than you think)",
+  "Sleeping gear (sleeping bag, tent or tarp, sleeping pad)",
+  "Food & water for the full op (MREs, snacks, hydration pack)",
+  "Extra batteries or charger for your replica",
+  "Radio + extra batteries",
+  "First aid kit / personal medications",
+  "Cash (some vendors on site)",
+  "Red light flashlight (white light = you get lit up at night)",
+];
+
+const SECTIONS = [
+  {
+    Icon: Clock,
+    title: "When to Arrive",
+    content: [
+      "Check-in usually opens Friday afternoon and closes in the evening — don't show up 20 minutes before it closes.",
+      "Aim to arrive at least 1–2 hours before check-in closes. You'll need time to set up camp, get through the line, pass chrono, and get your briefing.",
+      "Late arrivals miss the opening briefing and start the op already behind. Don't be that person.",
+    ],
+  },
+  {
+    Icon: FileText,
+    title: "Your Waiver",
+    content: [
+      "Print it. Sign it. Bring the physical copy. They will not accept it on your phone.",
+      "Download the MSW waiver from the official Milsim West website before you leave. If you forget it, you're not getting in.",
+      "If you're under 18, a parent or guardian signature is required on the waiver.",
+    ],
+  },
+  {
+    Icon: MapPin,
+    title: "Check-In Process",
+    content: [
+      "When you arrive, go straight to check-in. Don't set up camp first.",
+      "You'll hand over your waiver, show your ID, and get your wristband and faction assignment confirmed.",
+      "After check-in, your replica goes through chronograph testing. If your gun shoots over the event's FPS limit, you won't be able to use it — know your limits before you show up.",
+      "After chrono, you'll get a briefing on the AO (area of operations), rules, and your first objectives.",
+    ],
+  },
+  {
+    Icon: ShieldCheck,
+    title: "Chrono Limits",
+    content: [
+      "AEGs (automatic electric guns): typically 400 FPS with 0.20g BBs.",
+      "DMRs (semi-auto only): typically up to 450–500 FPS with a minimum engagement distance.",
+      "Bolt-action sniper rifles: up to 550 FPS with a minimum engagement distance.",
+      "Check the specific event page for exact limits — they can vary per op.",
+    ],
+  },
+];
+
+export default function BeforeYouGoPage() {
   return (
     <PageContainer>
-      <Link href="/newbie/milsim-west" className="mb-8 inline-flex items-center gap-1.5 font-mono text-xs tracking-widest uppercase text-muted-foreground transition-colors hover:text-tactical">
-        <ChevronLeft size={14} /> BACK TO MILSIM WEST
+      <Link
+        href="/newbie/milsim-west"
+        className="mb-8 inline-flex items-center gap-1.5 font-mono text-xs tracking-widest uppercase text-muted-foreground transition-colors hover:text-tactical"
+      >
+        <ChevronLeft size={14} />
+        BACK TO MILSIM WEST
       </Link>
-      <p className="font-mono text-xs tracking-[0.3em] uppercase text-tactical mb-3">// 01</p>
-      <h1 className="font-mono text-3xl font-bold text-foreground">BEFORE YOU GO</h1>
-      <p className="mt-4 text-sm text-muted-foreground">Content coming soon.</p>
+
+      <p className="mb-3 font-mono text-xs tracking-[0.3em] uppercase text-tactical">// 01</p>
+      <h1 className="font-mono text-3xl font-bold text-foreground sm:text-4xl">
+        BEFORE YOU GO
+      </h1>
+      <p className="mt-4 max-w-xl text-sm leading-relaxed text-muted-foreground">
+        Most newbies show up unprepared and spend the first few hours scrambling.
+        Read this before you leave the house.
+      </p>
+
+      {/* Warning banner */}
+      <div className="mt-8 flex items-start gap-3 border border-tactical/40 bg-tactical/5 p-4">
+        <AlertTriangle size={16} className="mt-0.5 shrink-0 text-tactical" />
+        <p className="text-sm text-muted-foreground">
+          <span className="font-bold text-foreground">No printed waiver = no entry.</span>{" "}
+          This is the #1 reason new players get turned away at the gate. Print it before you leave.
+        </p>
+      </div>
+
+      {/* Info sections */}
+      <div className="mt-12 flex flex-col gap-8">
+        {SECTIONS.map(({ Icon, title, content }) => (
+          <div key={title} className="border border-border bg-card p-6">
+            <div className="mb-4 flex items-center gap-3">
+              <Icon size={18} className="text-tactical shrink-0" />
+              <h2 className="font-mono text-sm font-bold tracking-widest uppercase text-foreground">
+                {title}
+              </h2>
+            </div>
+            <ul className="flex flex-col gap-2">
+              {content.map((item, i) => (
+                <li key={i} className="text-sm leading-relaxed text-muted-foreground">
+                  {item}
+                </li>
+              ))}
+            </ul>
+          </div>
+        ))}
+      </div>
+
+      {/* Checklist */}
+      <div className="mt-12">
+        <h2 className="mb-6 font-mono text-sm font-bold tracking-widest uppercase text-foreground">
+          // PACKING CHECKLIST
+        </h2>
+        <div className="grid gap-2 sm:grid-cols-2">
+          {CHECKLIST.map((item) => (
+            <div key={item} className="flex items-start gap-3 border border-border bg-card p-3">
+              <CheckCircle2 size={15} className="mt-0.5 shrink-0 text-tactical" />
+              <span className="text-sm text-muted-foreground">{item}</span>
+            </div>
+          ))}
+        </div>
+      </div>
     </PageContainer>
   );
 }

--- a/app/newbie/milsim-west/before-you-go/page.tsx
+++ b/app/newbie/milsim-west/before-you-go/page.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link";
-import { ChevronLeft, ChevronRight, AlertTriangle, Clock, Mail, MapPin, CheckCircle2, ShieldCheck } from "lucide-react";
+import { ChevronLeft, ChevronRight, AlertTriangle, Clock, Mail, MapPin, CheckCircle2, ShieldCheck, HeartPulse, Dumbbell } from "lucide-react";
 import PageContainer from "@/components/layout/page-container";
 import type { Metadata } from "next";
 
@@ -10,10 +10,11 @@ export const metadata: Metadata = {
 
 const ARRIVAL_CHECKLIST = [
   "Printed deployment orders (in a ziplock bag — keep them dry)",
+  "Medical card (in the same ziplock bag as your orders)",
   "Valid government-issued photo ID",
   "All red-highlighted gear from your deployment orders",
+  "Eye protection (full seal, ANSI rated)",
   "Airsoft replica + magazines (no BBs — provided at the event)",
-  "Red light flashlight (no white lights at night)",
   "Cash (~$50 for patches and miscellaneous)",
   "Personal medications",
 ];
@@ -61,10 +62,10 @@ export default function BeforeYouGoPage() {
               <span className="font-semibold text-foreground">Check your email and print them the moment they arrive.</span>
             </p>
             <p>
-              Your orders are a printed document with the event name, address, and a checklist at the bottom. That checklist is what the cadre uses during back check-in — they go through each item and initial it off. You need every red item on that list checked and signed before you can play.
+              Your orders are a printed document with the event name, address, and a checklist at the bottom. That checklist is what the cadre uses during bag check-in — they go through each item and initial it off. You need every red item on that list checked and signed before you can play.
             </p>
             <p>
-              During the game, any leader or cadre can stop you at any time and ask to see your orders. If your check isn't signed off or your paper is gone, you're out mid-op. Keep them on you at all times.
+              During the game, any leader or cadre can stop you at any time and ask to see your orders. If your check list isn't signed off or your paper is gone, you're out mid-op. Keep them on you at all times.
             </p>
             <div className="mt-1 rounded border border-border bg-background px-3 py-2">
               <span className="font-semibold text-foreground">First timer tip:</span> Put your deployment orders in a ziplock sandwich bag before you leave. Rain, sweat, river crossings — anything can destroy paper out in the field. If a leader asks for your orders and the paper is destroyed, you're getting kicked. Keep them dry.
@@ -145,7 +146,7 @@ export default function BeforeYouGoPage() {
               <span className="font-semibold text-foreground">Do not arrive before 1400</span> — the venue is private property.
             </p>
             <p>
-              The game kicks off around <span className="font-semibold text-foreground">2200–0000 (10 PM – midnight)</span>. Be prepared — you could be up all night, which is pretty much a full 24 hours on your feet by the time the game is over.
+              The game kicks off around <span className="font-semibold text-foreground">2200–0000 (10 PM – midnight)</span>. Be prepared — you could be up all night.
             </p>
             <div className="rounded border border-border bg-background px-3 py-2">
               <span className="font-semibold text-foreground">First timer tip:</span> Arrive early around 1400–1500. After check-in, eat, hydrate, talk to your platoon — and if there's downtime, take a nap. Seriously. You're going to need it. Alternatively, if you're not far from the venue, arriving a little later gives you more time to rest at home before the long night ahead.
@@ -175,6 +176,64 @@ export default function BeforeYouGoPage() {
                 <span className="font-semibold text-foreground">Do not bring your own BBs.</span>{" "}
                 BBs are provided at the event. Leave yours at home.
               </p>
+            </div>
+          </div>
+        </div>
+
+        {/* Medical Card */}
+        <div className="border border-border bg-card p-6">
+          <div className="mb-4 flex items-center gap-3">
+            <HeartPulse size={18} className="shrink-0 text-tactical" />
+            <h2 className="font-mono text-sm font-bold tracking-widest uppercase text-foreground">
+              Medical Card
+            </h2>
+          </div>
+          <div className="flex flex-col gap-3 text-sm leading-relaxed text-muted-foreground">
+            <p>
+              A medical card is a small piece of paper — laminated if you have it, written down if you don't — that stays on your person during the entire op. Sometimes cadre checks for it, sometimes they don't, but it's a listed item and more importantly it's a real safety tool.
+            </p>
+            <p>At minimum your medical card should include:</p>
+            <ul className="flex flex-col gap-1 pl-1">
+              {["Full name", "Home address", "Emergency contact name & phone number", "Blood type (if known)", "Any allergies", "Any medical conditions"].map((item) => (
+                <li key={item} className="flex items-center gap-2">
+                  <span className="text-tactical">—</span>
+                  <span>{item}</span>
+                </li>
+              ))}
+            </ul>
+            <div className="mt-1 rounded border border-border bg-background px-3 py-2">
+              <span className="font-semibold text-foreground">Tip:</span> Keep your medical card in the same ziplock bag as your deployment orders. One bag, two critical documents, both dry and accessible.
+            </div>
+          </div>
+        </div>
+
+        {/* Physical Fitness */}
+        <div className="border border-border bg-card p-6">
+          <div className="mb-4 flex items-center gap-3">
+            <Dumbbell size={18} className="shrink-0 text-tactical" />
+            <h2 className="font-mono text-sm font-bold tracking-widest uppercase text-foreground">
+              Physical Fitness
+            </h2>
+          </div>
+          <div className="flex flex-col gap-3 text-sm leading-relaxed text-muted-foreground">
+            <p>
+              A lot of people look at milsim like it's a movie — cool gear, cool moments. What they don't see is that you're going to be on your feet for potentially 24+ hours straight, walking and hiking with a replica that gets heavy, plus a vest loaded with gear. It's not the military, but it's not a walk in the park either.
+            </p>
+            <p>
+              If you're not in decent shape, you're going to feel it — and nobody wants to be the person slowing their squad down or quitting because they can't keep up. Do yourself and your platoon a favor and prepare before showing up.
+            </p>
+            <div className="grid gap-2 sm:grid-cols-2">
+              {[
+                { label: "Go running", detail: "Build your cardio before the event. Even a few weeks of light running makes a difference." },
+                { label: "Train with weight", detail: "Practice walking or running with a weighted vest or your actual gear so your body isn't shocked on game day." },
+                { label: "Break in your boots", detail: "Do not show up in a fresh pair of boots. Wear them on runs and walks beforehand — blisters 10 hours into an op are brutal." },
+                { label: "Get sleep before", detail: "You're going to be up all night. Don't show up already running on empty." },
+              ].map(({ label, detail }) => (
+                <div key={label} className="rounded border border-border bg-background p-3">
+                  <p className="font-semibold text-foreground">{label}</p>
+                  <p className="mt-1 text-xs leading-relaxed">{detail}</p>
+                </div>
+              ))}
             </div>
           </div>
         </div>

--- a/app/newbie/milsim-west/before-you-go/page.tsx
+++ b/app/newbie/milsim-west/before-you-go/page.tsx
@@ -217,7 +217,7 @@ export default function BeforeYouGoPage() {
           </div>
           <div className="flex flex-col gap-3 text-sm leading-relaxed text-muted-foreground">
             <p>
-              Milsim looks cool from the outside — and it is — but the physical reality hits different once you're in it. You're carrying a loaded vest and a replica for potentially 24 hours straight, moving through terrain, staying alert, and doing it all while sleep deprived. Body shock is real. People have blacked out and thrown up within the first 30 minutes. This isn't meant to scare you — it's meant to make sure you actually show up ready.
+              Milsim looks cool from the outside — and it is — but the physical reality hits different once you're in it. You're carrying a loaded vest and a replica for over 24 hours straight, moving through terrain, staying alert, and doing it all while sleep deprived. Body shock is real. People have blacked out and thrown up within the first 30 minutes. This isn't meant to scare you — it's meant to make sure you actually show up ready.
             </p>
             <p>
               Your fitness level directly affects your squad. One person who can't keep up slows everyone down and puts the team at a disadvantage. Start training with your actual gear — vest, replica, pack — so your body isn't shocked the moment the op starts. Put in the work before the event and you'll enjoy it a lot more.

--- a/app/newbie/milsim-west/before-you-go/page.tsx
+++ b/app/newbie/milsim-west/before-you-go/page.tsx
@@ -220,12 +220,11 @@ export default function BeforeYouGoPage() {
               Milsim looks cool from the outside — and it is — but the physical reality hits different once you're in it. You're carrying a loaded vest and a replica for potentially 24 hours straight, moving through terrain, staying alert, and doing it all while sleep deprived. Body shock is real. People have blacked out and thrown up within the first 30 minutes. This isn't meant to scare you — it's meant to make sure you actually show up ready.
             </p>
             <p>
-              Your fitness level directly affects your squad. One person who can't keep up slows everyone down and puts the team at a disadvantage. Put in the work before the event and you'll enjoy it a lot more.
+              Your fitness level directly affects your squad. One person who can't keep up slows everyone down and puts the team at a disadvantage. Start training with your actual gear — vest, replica, pack — so your body isn't shocked the moment the op starts. Put in the work before the event and you'll enjoy it a lot more.
             </p>
             <div className="grid gap-2 sm:grid-cols-2">
               {[
                 { label: "Go running", detail: "Be comfortable running 3 miles straight before the event. This op is a physical challenge — your cardio will be tested." },
-                { label: "Train with weight", detail: "Practice walking or running with a weighted vest or your actual gear so your body isn't shocked on game day." },
                 { label: "Practice rucking", detail: "Rucking means moving with your full kit — replica, vest, and a loaded pack on your back. Depending on the event you could ruck anywhere from 2 to 8 miles in a single day. Get comfortable carrying that weight before you show up, not during." },
                 { label: "Break in your boots", detail: "Do not show up in a fresh pair of boots. Wear them on runs and walks beforehand — blisters 10 hours into an op are brutal." },
                 { label: "Get sleep before", detail: "You're going to be up all night. Don't show up already running on empty." },

--- a/app/newbie/milsim-west/before-you-go/page.tsx
+++ b/app/newbie/milsim-west/before-you-go/page.tsx
@@ -194,7 +194,7 @@ export default function BeforeYouGoPage() {
             </p>
             <p>At minimum your medical card should include:</p>
             <ul className="flex flex-col gap-1 pl-1">
-              {["Full name", "Home address", "Emergency contact name & phone number", "Blood type (if known)", "Any allergies", "Any medical conditions"].map((item) => (
+              {["Full name", "Home address", "Emergency contact name & phone number", "Any allergies", "Any medical conditions"].map((item) => (
                 <li key={item} className="flex items-center gap-2">
                   <span className="text-tactical">—</span>
                   <span>{item}</span>
@@ -202,7 +202,7 @@ export default function BeforeYouGoPage() {
               ))}
             </ul>
             <div className="mt-1 rounded border border-border bg-background px-3 py-2">
-              <span className="font-semibold text-foreground">Tip:</span> Keep your medical card in the same ziplock bag as your deployment orders. One bag, two critical documents, both dry and accessible.
+              <span className="font-semibold text-foreground">Tip:</span> Keep both your deployment orders and medical card in the same ziplock bag and store it in your left chest pocket. If something happens in the field, that's the first place anyone is going to look — make it easy to find fast.
             </div>
           </div>
         </div>
@@ -217,14 +217,14 @@ export default function BeforeYouGoPage() {
           </div>
           <div className="flex flex-col gap-3 text-sm leading-relaxed text-muted-foreground">
             <p>
-              A lot of people look at milsim like it's a movie — cool gear, cool moments. What they don't see is that you're going to be on your feet for potentially 24+ hours straight, walking and hiking with a replica that gets heavy, plus a vest loaded with gear. It's not the military, but it's not a walk in the park either.
+              Milsim looks cool from the outside — and it is — but the physical reality hits different once you're in it. You're carrying a loaded vest and a replica for potentially 24 hours straight, moving through terrain, staying alert, and doing it all while sleep deprived. Body shock is real. People have blacked out and thrown up within the first 30 minutes. This isn't meant to scare you — it's meant to make sure you actually show up ready.
             </p>
             <p>
-              If you're not in decent shape, you're going to feel it — and nobody wants to be the person slowing their squad down or quitting because they can't keep up. Do yourself and your platoon a favor and prepare before showing up.
+              Your fitness level directly affects your squad. One person who can't keep up slows everyone down and puts the team at a disadvantage. Put in the work before the event and you'll enjoy it a lot more.
             </p>
             <div className="grid gap-2 sm:grid-cols-2">
               {[
-                { label: "Go running", detail: "Build your cardio before the event. Even a few weeks of light running makes a difference." },
+                { label: "Go running", detail: "Be comfortable running 3 miles straight before the event. This op is a physical challenge — your cardio will be tested." },
                 { label: "Train with weight", detail: "Practice walking or running with a weighted vest or your actual gear so your body isn't shocked on game day." },
                 { label: "Break in your boots", detail: "Do not show up in a fresh pair of boots. Wear them on runs and walks beforehand — blisters 10 hours into an op are brutal." },
                 { label: "Get sleep before", detail: "You're going to be up all night. Don't show up already running on empty." },

--- a/app/newbie/milsim-west/before-you-go/page.tsx
+++ b/app/newbie/milsim-west/before-you-go/page.tsx
@@ -9,15 +9,12 @@ export const metadata: Metadata = {
 };
 
 const ARRIVAL_CHECKLIST = [
-  "Printed deployment orders (sent via email — keep an eye on your inbox)",
+  "Printed deployment orders (in a ziplock bag — keep them dry)",
   "Valid government-issued photo ID",
-  "All red-highlighted gear from the TACSOP packing list",
-  "Airsoft replica + magazines + BBs",
-  "Radio + batteries",
-  "Sleeping gear (sleeping bag, pad, tent or tarp)",
-  "Food & water for the full op",
+  "All red-highlighted gear from your deployment orders packing list",
+  "Airsoft replica + magazines (no BBs — they are provided at the event)",
   "Red light flashlight (no white lights at night)",
-  "Cash (some vendors on site)",
+  "Cash (~$50 for food, patches, etc.)",
   "Personal medications",
 ];
 
@@ -60,17 +57,19 @@ export default function BeforeYouGoPage() {
           </div>
           <div className="flex flex-col gap-3 text-sm leading-relaxed text-muted-foreground">
             <p>
-              MSW will send your deployment orders to the email you used to buy your ticket — sometimes weeks in advance, sometimes the day before. <span className="font-semibold text-foreground">Check your email and print them the moment they arrive.</span>
+              MSW will send your deployment orders to the email you used to buy your ticket — sometimes weeks in advance, sometimes the day before.{" "}
+              <span className="font-semibold text-foreground">Check your email and print them the moment they arrive.</span>
             </p>
             <p>
-              Your orders contain your faction assignment, rules of engagement, and a gear checklist. All items highlighted in red on that list are <span className="font-semibold text-foreground">mandatory</span> — show up missing any of them and you will be turned away and told not to come back until you have everything.
+              Your orders contain your faction assignment, rules of engagement, and a gear checklist. All items highlighted in red on that list are{" "}
+              <span className="font-semibold text-foreground">mandatory</span> — show up missing any of them and you will be turned away. Items in black are recommended but optional.
             </p>
             <p>
-              Items in black are recommended but optional. Don't stress those — focus on the red ones first.
+              During the game, any leader or cadre can stop you at any time and ask to see your papers. If your gear check isn't signed off you're out of the game mid-op. Keep your orders on you at all times.
             </p>
-            <p>
-              During the game, any leader or cadre can stop you at any time and ask to see your papers. If your gear check isn't signed off, you're out of the game — mid-op. Keep your orders on you.
-            </p>
+            <div className="mt-1 rounded border border-border bg-background px-3 py-2">
+              <span className="font-semibold text-foreground">First timer tip:</span> Put your deployment orders in a ziplock sandwich bag before you leave. Rain, sweat, river crossings — anything can destroy paper out in the field. If a leader asks for your orders and the paper is destroyed, you're getting kicked. Keep them dry.
+            </div>
           </div>
         </div>
 
@@ -84,15 +83,16 @@ export default function BeforeYouGoPage() {
           </div>
           <div className="flex flex-col gap-3 text-sm leading-relaxed text-muted-foreground">
             <p>
-              In-processing opens at <span className="font-semibold text-foreground">1400 (2:00 PM)</span> and closes at <span className="font-semibold text-foreground">1800 (6:00 PM)</span>.{" "}
+              In-processing opens at <span className="font-semibold text-foreground">1400 (2:00 PM)</span> and closes at{" "}
+              <span className="font-semibold text-foreground">1800 (6:00 PM)</span>.{" "}
               <span className="font-semibold text-foreground">Do not arrive before 1400</span> — the venue is private property.
             </p>
             <p>
-              The game officially kicks off around <span className="font-semibold text-foreground">2200–0000 (10 PM–midnight)</span>, so you'll have several hours to get settled after check-in.
+              The game officially kicks off around <span className="font-semibold text-foreground">2200–0000 (10 PM – midnight)</span>, so you'll have several hours after check-in before it starts. You're going to be up all night — if you think about it, you're essentially awake for two full days straight.
             </p>
-            <p className="rounded border border-border bg-background px-3 py-2">
-              <span className="font-semibold text-foreground">First timer tip:</span> Arrive early — around 1400–1500. Use the extra time to set up your sleeping area, eat, hydrate, and mentally prep before the game starts. You don't want to be rushing through check-in and setting up camp in the dark right before op start.
-            </p>
+            <div className="mt-1 rounded border border-border bg-background px-3 py-2">
+              <span className="font-semibold text-foreground">First timer tip:</span> Arrive early around 1400–1500. Use that extra time to talk to the people in your platoon, eat something, hydrate, and mentally prepare. Just relax — because once the game starts, that's it.
+            </div>
           </div>
         </div>
 
@@ -111,10 +111,26 @@ export default function BeforeYouGoPage() {
 
             <ol className="flex flex-col gap-3">
               {[
-                { step: "01", text: "Arrive and go directly to your assigned platoon area — don't set up camp first." },
-                { step: "02", text: "Lay out your gear. A cadre (the admin or faction leader) will do your back check-in — they inspect all red-highlighted items from your orders and initial each one off." },
-                { step: "03", text: "Once your gear check is signed off, head to chrono. Your replica must pass the FPS check to play." },
-                { step: "04", text: "If you're running a BFA (Blank Firing Adapter), let the cadre know at back check-in — there's a separate process for blanks and they'll point you in the right direction." },
+                {
+                  step: "01",
+                  text: "When you arrive, go directly to your assigned platoon area. Do not set up camp — you are not camping at the spawn or check-in area.",
+                },
+                {
+                  step: "02",
+                  text: "Find the bag check-in area. There will be a group of people with a cadre calling out items from the packing list — that's where you lay your gear out for inspection, not where you lined up with your platoon.",
+                },
+                {
+                  step: "03",
+                  text: "The cadre inspects all red-highlighted items and initials them off on your orders. Once every item is checked, you're cleared to move on.",
+                },
+                {
+                  step: "04",
+                  text: "Head to chrono. Your replica must pass the FPS check to play.",
+                },
+                {
+                  step: "05",
+                  text: "Running a BFA (Blank Firing Adapter)? Let the cadre know at back check-in — there's a separate process and they'll point you in the right direction.",
+                },
               ].map(({ step, text }) => (
                 <li key={step} className="flex items-start gap-3">
                   <span className="font-mono text-xs font-bold text-tactical shrink-0 mt-0.5">{step}</span>
@@ -123,7 +139,6 @@ export default function BeforeYouGoPage() {
               ))}
             </ol>
 
-            {/* Links to other sections */}
             <div className="mt-2 flex flex-wrap gap-3">
               <Link
                 href="/newbie/milsim-west/gear"
@@ -151,11 +166,15 @@ export default function BeforeYouGoPage() {
           </div>
           <div className="flex flex-col gap-3 text-sm leading-relaxed text-muted-foreground">
             <p>
-              MSW does not allow DMRs. You're running a standard AEG. Check the specific event's orders for the exact FPS limit — it's typically around <span className="font-semibold text-foreground">400 FPS with 0.20g BBs</span>.
+              MSW does not allow DMRs — standard AEGs only. Check your specific event's deployment orders for the exact FPS limit.
             </p>
-            <p>
-              If your replica shoots over the limit it doesn't play — period. Know your gun before you show up.
-            </p>
+            <div className="flex items-start gap-3 rounded border border-tactical/40 bg-tactical/5 px-3 py-2">
+              <AlertTriangle size={14} className="mt-0.5 shrink-0 text-tactical" />
+              <p>
+                <span className="font-semibold text-foreground">Do not bring your own BBs.</span>{" "}
+                BBs are provided at the event. Leave yours at home.
+              </p>
+            </div>
           </div>
         </div>
       </div>
@@ -166,8 +185,10 @@ export default function BeforeYouGoPage() {
           // DAY-OF CHECKLIST
         </h2>
         <p className="mb-6 text-sm text-muted-foreground">
-          The essentials for arriving. For faction-specific gear and full loadout see the{" "}
-          <Link href="/newbie/milsim-west/gear" className="text-tactical hover:underline">Gear Guide</Link>.
+          The essentials for arriving. For full loadout and faction-specific gear see the{" "}
+          <Link href="/newbie/milsim-west/gear" className="text-tactical hover:underline">
+            Gear Guide
+          </Link>.
         </p>
         <div className="grid gap-2 sm:grid-cols-2">
           {ARRIVAL_CHECKLIST.map((item) => (


### PR DESCRIPTION
## Summary
- Full Before You Go page with real Milsim West content: deployment orders, check-in process, arrival times, chrono rules, medical card, physical fitness section
- Day-of packing checklist
- All content sections complete with first-timer tips

## Changes
- Deployment orders: email watch, print immediately, mid-game paper check, ziplock tip
- Check-in: Facebook group for platoon assignment, 5-step numbered process, links to Gear/Factions
- When to Arrive: 1400–1800 window, game kicks off 2200–0000, arrival strategy tips
- Chrono: FPS limit, BBs provided
- Medical card: fields, ziplock + left chest pocket tip
- Physical fitness: body shock warning, 4-card grid (running, rucking, boots, sleep)