### PR TITLE
feat: rebrand to MILSIM READY

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -6,7 +6,7 @@ import Footer from "@/components/layout/footer";
 import "@/styles/globals.css";
 
 export const metadata: Metadata = {
-  title: "MilsimReady",
+  title: "Milsim Ready",
   description: "Gear up, learn the lingo, and survive your first milsim event.",
 };
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -6,7 +6,7 @@ import Footer from "@/components/layout/footer";
 import "@/styles/globals.css";
 
 export const metadata: Metadata = {
-  title: "Milsim",
+  title: "MilsimReady",
   description: "Gear up, learn the lingo, and survive your first milsim event.",
 };
 

--- a/app/newbie/milsim-west/page.tsx
+++ b/app/newbie/milsim-west/page.tsx
@@ -4,7 +4,7 @@ import PageContainer from "@/components/layout/page-container";
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
-  title: "Milsim West Guide — MilsimReady",
+  title: "Milsim West Guide — Milsim Ready",
   description: "The complete first-timer guide for Milsim West events.",
 };
 

--- a/app/newbie/milsim-west/page.tsx
+++ b/app/newbie/milsim-west/page.tsx
@@ -4,7 +4,7 @@ import PageContainer from "@/components/layout/page-container";
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
-  title: "Milsim West Guide — MILSIM",
+  title: "Milsim West Guide — MilsimReady",
   description: "The complete first-timer guide for Milsim West events.",
 };
 

--- a/app/newbie/page.tsx
+++ b/app/newbie/page.tsx
@@ -4,7 +4,7 @@ import PageContainer from "@/components/layout/page-container";
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
-  title: "Newbie Guide — MILSIM",
+  title: "Newbie Guide — MilsimReady",
   description: "Everything a first-timer needs before stepping onto the field.",
 };
 

--- a/app/newbie/page.tsx
+++ b/app/newbie/page.tsx
@@ -4,7 +4,7 @@ import PageContainer from "@/components/layout/page-container";
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
-  title: "Newbie Guide — MilsimReady",
+  title: "Newbie Guide — Milsim Ready",
   description: "Everything a first-timer needs before stepping onto the field.",
 };
 

--- a/components/layout/footer.tsx
+++ b/components/layout/footer.tsx
@@ -55,7 +55,7 @@ export default function Footer() {
 
         <div className="mt-10 border-t border-border pt-6">
           <p className="font-mono text-xs text-muted-foreground">
-            &copy; {new Date().getFullYear()} MILSIM — ALL RIGHTS RESERVED
+            &copy; {new Date().getFullYear()} MILSIMREADY — ALL RIGHTS RESERVED
           </p>
         </div>
       </div>

--- a/components/layout/footer.tsx
+++ b/components/layout/footer.tsx
@@ -55,7 +55,7 @@ export default function Footer() {
 
         <div className="mt-10 border-t border-border pt-6">
           <p className="font-mono text-xs text-muted-foreground">
-            &copy; {new Date().getFullYear()} MILSIMREADY — ALL RIGHTS RESERVED
+            &copy; {new Date().getFullYear()} MILSIM READY — ALL RIGHTS RESERVED
           </p>
         </div>
       </div>

--- a/components/layout/header.tsx
+++ b/components/layout/header.tsx
@@ -23,7 +23,7 @@ export default function Header() {
           href="/"
           className="font-mono text-sm font-bold tracking-widest uppercase text-foreground hover:text-tactical transition-colors"
         >
-          MILSIMREADY
+          MILSIM READY
         </Link>
 
         {/* Desktop nav */}

--- a/components/layout/header.tsx
+++ b/components/layout/header.tsx
@@ -23,7 +23,7 @@ export default function Header() {
           href="/"
           className="font-mono text-sm font-bold tracking-widest uppercase text-foreground hover:text-tactical transition-colors"
         >
-          MILSIM
+          MILSIMREADY
         </Link>
 
         {/* Desktop nav */}


### PR DESCRIPTION
## Summary
- Renamed site from MILSIM to MILSIM READY across header, footer, and all page titles
- Domain is milsimready.com (one word), display name uses a space for readability