### PR TITLE
Fix platoon assignment info and faction selection

### DIFF
--- a/app/newbie/milsim-west/before-you-go/page.tsx
+++ b/app/newbie/milsim-west/before-you-go/page.tsx
@@ -92,7 +92,10 @@ export default function BeforeYouGoPage() {
           </div>
           <div className="flex flex-col gap-4 text-sm leading-relaxed text-muted-foreground">
             <p>
-              Before the event, join the <span className="font-semibold text-foreground">MSW Facebook group for your faction</span>. Your platoon assignment will be posted there — know it before you arrive.
+              After purchasing your ticket, join the <span className="font-semibold text-foreground">private Facebook group for your faction</span> — the link is on the MSW website. Your platoon and squad assignment will be posted there. Know it before you arrive.
+            </p>
+            <p>
+              Want to team up with a friend? Request it early — either in the comments when buying your ticket or by reaching out to the group admins before the event. The earlier you ask, the easier it is for them to organize. Don't wait until you're already on site.
             </p>
             <ol className="flex flex-col gap-3">
               {[

--- a/app/newbie/milsim-west/factions/page.tsx
+++ b/app/newbie/milsim-west/factions/page.tsx
@@ -73,7 +73,7 @@ export default function FactionsPage() {
       <div className="mt-8 border border-border bg-card p-5">
         <p className="font-mono text-xs font-bold tracking-widest uppercase text-foreground mb-2">How Assignment Works</p>
         <p className="text-sm leading-relaxed text-muted-foreground">
-          MSW assigns factions to keep numbers balanced on both sides. You may be able to request a side when you register, but it's not guaranteed. Make sure your kit matches your assigned faction — showing up in MultiCam on RUFOR or Flora on NATO is not going to fly. Check your deployment orders.
+          You pick your faction when you purchase your ticket — it's guaranteed. MSW balances the sides by capping each faction: once a faction sells out, it's full and you'll need to pick another. Register early if you have a preferred side. Make sure your kit matches your faction — showing up in MultiCam on RUFOR or Flora on NATO is not going to fly.
         </p>
       </div>
     </PageContainer>

--- a/app/newbie/milsim-west/lingo/page.tsx
+++ b/app/newbie/milsim-west/lingo/page.tsx
@@ -91,7 +91,7 @@ export default function LingoPage() {
               {
                 level: "PLATOON",
                 label: "Your group — e.g. Platoon 1",
-                detail: "Led by your PL. This is the unit you belong to for the entire event. You'll know your platoon number from your deployment orders.",
+                detail: "Led by your PL. This is the unit you belong to for the entire event. After buying your ticket, join the private Facebook group for your faction — the link is on the MSW website. Your platoon and squad assignment gets posted there. If you want to team up with a friend, request it early or put their name in the comments when purchasing your ticket.",
                 indent: 1,
               },
               {


### PR DESCRIPTION
## Summary
- Corrected platoon/squad assignment to reference Facebook group, not deployment orders
- Added teammate request tip to Before You Go and Platoon Lingo pages
- Fixed faction selection copy — guaranteed at purchase, sells out when full

🤖 Generated with [Claude Code](https://claude.com/claude-code)