### PR TITLE
Design pass — before-you-go, gear guide, milsim-west index

### DIFF
--- a/app/newbie/milsim-west/before-you-go/page.tsx
+++ b/app/newbie/milsim-west/before-you-go/page.tsx
@@ -9,14 +9,14 @@ export const metadata: Metadata = {
 };
 
 const ARRIVAL_CHECKLIST = [
-  "Printed deployment orders (in a ziplock bag — keep them dry)",
-  "Medical card (in the same ziplock bag as your orders)",
-  "Valid government-issued photo ID",
-  "All red-highlighted gear from your deployment orders",
-  "Eye protection (full seal, ANSI rated) — on at all times, including while sleeping",
-  "Airsoft replica + magazines (no BBs — provided at the event)",
-  "Cash (~$50 for patches and miscellaneous)",
-  "Personal medications",
+  { icon: Mail, text: "Printed deployment orders (in a ziplock bag — keep them dry)" },
+  { icon: HeartPulse, text: "Medical card (in the same ziplock bag as your orders)" },
+  { icon: ShieldCheck, text: "Valid government-issued photo ID" },
+  { icon: CheckCircle2, text: "All red-highlighted gear from your deployment orders" },
+  { icon: CheckCircle2, text: "Eye protection (full seal, ANSI rated) — on at all times, including while sleeping" },
+  { icon: CheckCircle2, text: "Airsoft replica + magazines (no BBs — provided at the event)" },
+  { icon: CheckCircle2, text: "Cash (~$50 for patches and miscellaneous)" },
+  { icon: CheckCircle2, text: "Personal medications" },
 ];
 
 export default function BeforeYouGoPage() {
@@ -39,104 +39,86 @@ export default function BeforeYouGoPage() {
 
       {/* Critical warnings */}
       <div className="mt-8 flex flex-col gap-3">
-        <div className="flex items-start gap-3 border border-tactical/40 bg-tactical/5 p-4">
-          <AlertTriangle size={16} className="mt-0.5 shrink-0 text-tactical" />
-          <p className="text-sm text-muted-foreground">
-            <span className="font-bold text-foreground">No deployment orders = no entry.</span>{" "}
-            MSW will not have your orders on hand. If you don't print them and bring them, you are not getting in — no exceptions.
-          </p>
+        <div className="flex items-start gap-4 border-l-4 border-tactical bg-tactical/5 p-4">
+          <AlertTriangle size={20} className="shrink-0 text-tactical mt-0.5" />
+          <div>
+            <p className="font-mono text-sm font-bold text-foreground">NO DEPLOYMENT ORDERS = NO ENTRY</p>
+            <p className="mt-1 text-sm text-muted-foreground">MSW will not have your orders on hand. If you don't print them and bring them, you are not getting in — no exceptions.</p>
+          </div>
         </div>
-        <div className="flex items-start gap-3 border border-tactical/40 bg-tactical/5 p-4">
-          <AlertTriangle size={16} className="mt-0.5 shrink-0 text-tactical" />
-          <p className="text-sm text-muted-foreground">
-            <span className="font-bold text-foreground">Eye pro on at all times. No exceptions.</span>{" "}
-            During setup, during the op, during breaks, and yes — while you are sleeping. Getting caught without it is an ejection offense.
-          </p>
+        <div className="flex items-start gap-4 border-l-4 border-tactical bg-tactical/5 p-4">
+          <AlertTriangle size={20} className="shrink-0 text-tactical mt-0.5" />
+          <div>
+            <p className="font-mono text-sm font-bold text-foreground">EYE PRO ON AT ALL TIMES</p>
+            <p className="mt-1 text-sm text-muted-foreground">During setup, during the op, during breaks, and yes — while you are sleeping. Getting caught without it is an ejection offense.</p>
+          </div>
         </div>
       </div>
 
-      <div className="mt-12 flex flex-col gap-6">
+      <div className="mt-12 flex flex-col gap-10">
 
         {/* Deployment Orders */}
-        <div className="border border-border bg-card p-6">
-          <div className="mb-4 flex items-center gap-3">
-            <Mail size={18} className="shrink-0 text-tactical" />
-            <h2 className="font-mono text-sm font-bold tracking-widest uppercase text-foreground">
-              Deployment Orders
-            </h2>
+        <div>
+          <div className="flex items-center gap-4 mb-6">
+            <div className="flex items-center justify-center w-14 h-14 border border-border bg-card">
+              <Mail size={28} className="text-tactical" />
+            </div>
+            <div>
+              <h2 className="font-mono text-lg font-bold text-foreground">Deployment Orders</h2>
+              <p className="text-sm text-muted-foreground">Sent to your email — print them the moment they arrive</p>
+            </div>
           </div>
-          <div className="flex flex-col gap-3 text-sm leading-relaxed text-muted-foreground">
+          <div className="flex flex-col gap-3 text-sm leading-relaxed text-muted-foreground pl-[4.5rem]">
             <p>
-              MSW will send your deployment orders to the email you used to buy your ticket — sometimes weeks in advance, sometimes the day before.{" "}
+              MSW will email your deployment orders — sometimes weeks in advance, sometimes the day before.{" "}
               <span className="font-semibold text-foreground">Check your email and print them the moment they arrive.</span>
             </p>
             <p>
-              Your orders are a printed document with the event name, address, and a checklist at the bottom. That checklist is what the cadre uses during bag check-in — they go through each item and initial it off. You need every red item on that list checked and signed before you can play.
+              Your orders are a printed document with the event name, address, and a checklist at the bottom. Cadre goes through each red-highlighted item and initials it off. You need every red item checked and signed before you can play.
             </p>
             <p>
-              During the game, any leader or cadre can stop you at any time and ask to see your orders. If your check list isn't signed off or your paper is gone, you're out mid-op. Keep them on you at all times.
+              During the game, any leader or cadre can stop you at any time and ask to see your orders. If your checklist isn't signed off or your paper is gone, you're out mid-op. Keep them on you at all times.
             </p>
-            <div className="mt-1 rounded border border-border bg-background px-3 py-2">
-              <span className="font-semibold text-foreground">First timer tip:</span> Put your deployment orders in a ziplock sandwich bag before you leave. Rain, sweat, river crossings — anything can destroy paper out in the field. If a leader asks for your orders and the paper is destroyed, you're getting kicked. Keep them dry.
+            <div className="rounded border border-border bg-card px-4 py-3">
+              <span className="font-semibold text-foreground">Tip:</span> Put your orders in a ziplock sandwich bag. Rain, sweat, river crossings — anything can destroy paper in the field.
             </div>
           </div>
         </div>
 
-        {/* Check-in Process — intentionally before When to Arrive */}
-        <div className="border border-border bg-card p-6">
-          <div className="mb-4 flex items-center gap-3">
-            <MapPin size={18} className="shrink-0 text-tactical" />
-            <h2 className="font-mono text-sm font-bold tracking-widest uppercase text-foreground">
-              Check-In Process
-            </h2>
+        {/* Check-In */}
+        <div>
+          <div className="flex items-center gap-4 mb-6">
+            <div className="flex items-center justify-center w-14 h-14 border border-border bg-card">
+              <MapPin size={28} className="text-tactical" />
+            </div>
+            <div>
+              <h2 className="font-mono text-lg font-bold text-foreground">Check-In Process</h2>
+              <p className="text-sm text-muted-foreground">Know your platoon before you arrive</p>
+            </div>
           </div>
-          <div className="flex flex-col gap-4 text-sm leading-relaxed text-muted-foreground">
-            <p>
-              After purchasing your ticket, join the <span className="font-semibold text-foreground">private Facebook group for your faction</span> — the link is on the MSW website. Your platoon and squad assignment will be posted there. Know it before you arrive.
-            </p>
-            <p>
-              Want to team up with a friend? Request it early — either in the comments when buying your ticket or by reaching out to the group admins before the event. The earlier you ask, the easier it is for them to organize. Don't wait until you're already on site.
-            </p>
-            <ol className="flex flex-col gap-3">
+          <div className="flex flex-col gap-3 pl-[4.5rem]">
+            <div className="rounded border border-border bg-card px-4 py-3 text-sm text-muted-foreground">
+              After buying your ticket, join the <span className="font-semibold text-foreground">private Facebook group for your faction</span> — the link is on the MSW website. Your platoon and squad assignment will be posted there. Want to team up with a friend? Put their name in the comments when purchasing or message the group admins early.
+            </div>
+            <div className="flex flex-col gap-2 mt-1">
               {[
-                {
-                  step: "01",
-                  text: "When you arrive, go directly to your assigned platoon area. Do not set up camp — you are not camping at the spawn or check-in area.",
-                },
-                {
-                  step: "02",
-                  text: "Find the bag check-in area. There will be a group of people with a cadre calling out items — that's where you lay your gear out for inspection, not just where you lined up with your platoon.",
-                },
-                {
-                  step: "03",
-                  text: "The cadre goes through all the red-highlighted items and initials them off on your orders. Once everything is checked, you're cleared.",
-                },
-                {
-                  step: "04",
-                  text: "Head to chrono. Your replica must pass the FPS check to play.",
-                },
-                {
-                  step: "05",
-                  text: "Running a BFA (Blank Firing Adapter)? Let the cadre know at back check-in — there's a separate process and they'll point you in the right direction.",
-                },
+                { step: "01", text: "When you arrive, go directly to your assigned platoon area. Do not set up camp." },
+                { step: "02", text: "Find the bag check-in area. Lay your gear out for cadre inspection." },
+                { step: "03", text: "Cadre goes through all red-highlighted items and initials them off your orders." },
+                { step: "04", text: "Head to chrono. Your replica must pass the FPS check to play." },
+                { step: "05", text: "Running a BFA? Let cadre know at bag check-in — there's a separate process." },
               ].map(({ step, text }) => (
-                <li key={step} className="flex items-start gap-3">
-                  <span className="font-mono text-xs font-bold text-tactical shrink-0 mt-0.5">{step}</span>
-                  <span>{text}</span>
-                </li>
+                <div key={step} className="flex items-start gap-4 border border-border bg-card p-4">
+                  <span className="font-mono text-lg font-bold text-tactical shrink-0 leading-none">{step}</span>
+                  <span className="text-sm text-muted-foreground">{text}</span>
+                </div>
               ))}
-            </ol>
+            </div>
             <div className="mt-2 flex flex-wrap gap-3">
-              <Link
-                href="/newbie/milsim-west/gear"
-                className="inline-flex items-center gap-1 font-mono text-xs tracking-widest uppercase text-tactical hover:underline"
-              >
+              <Link href="/newbie/milsim-west/gear" className="inline-flex items-center gap-1 font-mono text-xs tracking-widest uppercase text-tactical hover:underline">
                 SEE GEAR GUIDE <ChevronRight size={11} />
               </Link>
-              <Link
-                href="/newbie/milsim-west/factions"
-                className="inline-flex items-center gap-1 font-mono text-xs tracking-widest uppercase text-tactical hover:underline"
-              >
+              <Link href="/newbie/milsim-west/factions" className="inline-flex items-center gap-1 font-mono text-xs tracking-widest uppercase text-tactical hover:underline">
                 SEE FACTIONS <ChevronRight size={11} />
               </Link>
             </div>
@@ -144,31 +126,44 @@ export default function BeforeYouGoPage() {
         </div>
 
         {/* When to Arrive */}
-        <div className="border border-border bg-card p-6">
-          <div className="mb-4 flex items-center gap-3">
-            <Clock size={18} className="shrink-0 text-tactical" />
-            <h2 className="font-mono text-sm font-bold tracking-widest uppercase text-foreground">
-              When to Arrive
-            </h2>
+        <div>
+          <div className="flex items-center gap-4 mb-6">
+            <div className="flex items-center justify-center w-14 h-14 border border-border bg-card">
+              <Clock size={28} className="text-tactical" />
+            </div>
+            <div>
+              <h2 className="font-mono text-lg font-bold text-foreground">When to Arrive</h2>
+              <p className="text-sm text-muted-foreground">Don't show up before 1400 — private property</p>
+            </div>
           </div>
-          <div className="flex flex-col gap-3 text-sm leading-relaxed text-muted-foreground">
-            <p>
-              In-processing opens at <span className="font-semibold text-foreground">1400 (2:00 PM)</span> and closes at{" "}
-              <span className="font-semibold text-foreground">1800 (6:00 PM)</span>.{" "}
-              <span className="font-semibold text-foreground">Do not arrive before 1400</span> — the venue is private property.
+          <div className="flex flex-col gap-4 pl-[4.5rem]">
+            {/* Time blocks */}
+            <div className="grid grid-cols-2 gap-3">
+              <div className="border border-border bg-card p-4 text-center">
+                <p className="font-mono text-3xl font-bold text-tactical">1400</p>
+                <p className="font-mono text-xs text-muted-foreground mt-1 tracking-widest uppercase">Check-in Opens · 2:00 PM</p>
+              </div>
+              <div className="border border-border bg-card p-4 text-center">
+                <p className="font-mono text-3xl font-bold text-foreground">1800</p>
+                <p className="font-mono text-xs text-muted-foreground mt-1 tracking-widest uppercase">Check-in Closes · 6:00 PM</p>
+              </div>
+            </div>
+            <div className="border border-border bg-card p-4 text-center">
+              <p className="font-mono text-2xl font-bold text-foreground">2200 – 0000</p>
+              <p className="font-mono text-xs text-muted-foreground mt-1 tracking-widest uppercase">Game Kicks Off · 10 PM – Midnight</p>
+            </div>
+            <p className="text-sm text-muted-foreground leading-relaxed">
+              <span className="font-semibold text-foreground">Do not arrive before 1400</span> — the venue is private property. The game kicks off around 2200–0000 (10 PM – midnight). Be prepared — you could be up all night.
             </p>
-            <p>
-              The game kicks off around <span className="font-semibold text-foreground">2200–0000 (10 PM – midnight)</span>. Be prepared — you could be up all night.
-            </p>
-            <div className="rounded border border-border bg-background px-3 py-2">
+            <div className="rounded border border-border bg-card px-4 py-3 text-sm text-muted-foreground">
               <span className="font-semibold text-foreground">First timer tip:</span> Arrive early around 1400–1500. After check-in, eat, hydrate, talk to your platoon — and if there's downtime, take a nap. Seriously. You're going to need it. Alternatively, if you're not far from the venue, arriving a little later gives you more time to rest at home before the long night ahead.
             </div>
-            <div className="rounded border border-border bg-background px-3 py-2">
+            <div className="rounded border border-border bg-card px-4 py-3 text-sm text-muted-foreground">
               <span className="font-semibold text-foreground">Bonus tip:</span> Bring a separate water bottle and snacks that are NOT part of your game gear. You'll be on site for several hours before the game even starts — don't burn through your field rations just sitting around waiting. Eat before you go and keep your game food and water sealed for the actual op.
             </div>
-            <div className="flex items-start gap-3 rounded border border-tactical/40 bg-tactical/5 px-3 py-2">
-              <AlertTriangle size={14} className="mt-0.5 shrink-0 text-tactical" />
-              <p className="text-sm">
+            <div className="flex items-start gap-3 border-l-4 border-tactical bg-tactical/5 px-4 py-3">
+              <AlertTriangle size={16} className="mt-0.5 shrink-0 text-tactical" />
+              <p className="text-sm text-muted-foreground">
                 <span className="font-semibold text-foreground">Do not go to your car to sleep after in-processing.</span>{" "}
                 Once you're checked in, going back to your car for any reason requires a cadre escort and full gear re-inspection. Going there to sleep means you are out of the event — no return, no exceptions.
               </p>
@@ -177,21 +172,27 @@ export default function BeforeYouGoPage() {
         </div>
 
         {/* Chrono */}
-        <div className="border border-border bg-card p-6">
-          <div className="mb-4 flex items-center gap-3">
-            <ShieldCheck size={18} className="shrink-0 text-tactical" />
-            <h2 className="font-mono text-sm font-bold tracking-widest uppercase text-foreground">
-              Chrono
-            </h2>
+        <div>
+          <div className="flex items-center gap-4 mb-6">
+            <div className="flex items-center justify-center w-14 h-14 border border-border bg-card">
+              <ShieldCheck size={28} className="text-tactical" />
+            </div>
+            <div>
+              <h2 className="font-mono text-lg font-bold text-foreground">Chrono</h2>
+              <p className="text-sm text-muted-foreground">Your replica must pass before you can play</p>
+            </div>
           </div>
-          <div className="flex flex-col gap-3 text-sm leading-relaxed text-muted-foreground">
-            <p>
-              Standard AEGs are limited to{" "}
-              <span className="font-semibold text-foreground">366 fps measured with a 0.25g BB (1.5 joules)</span>. MSW chronos by joule energy, not raw FPS — the number on the screen changes depending on what BB weight the operator uses. Check your specific event's orders for the exact limit.
+          <div className="flex flex-col gap-3 pl-[4.5rem]">
+            <div className="border border-border bg-card p-6 text-center">
+              <p className="font-mono text-4xl font-bold text-tactical">366 FPS</p>
+              <p className="font-mono text-xs text-muted-foreground mt-2 tracking-widest uppercase">With 0.25g BB · 1.5 Joules</p>
+            </div>
+            <p className="text-sm text-muted-foreground">
+              MSW chronos by joule energy, not raw FPS — the number on screen changes depending on BB weight the operator uses. Check your specific event's orders for the exact limit.
             </p>
-            <div className="flex items-start gap-3 rounded border border-tactical/40 bg-tactical/5 px-3 py-2">
-              <AlertTriangle size={14} className="mt-0.5 shrink-0 text-tactical" />
-              <p>
+            <div className="flex items-start gap-3 border-l-4 border-tactical bg-tactical/5 px-4 py-3">
+              <AlertTriangle size={16} className="mt-0.5 shrink-0 text-tactical" />
+              <p className="text-sm text-muted-foreground">
                 <span className="font-semibold text-foreground">Do not bring your own BBs.</span>{" "}
                 BBs are provided at the event. Leave yours at home.
               </p>
@@ -200,57 +201,62 @@ export default function BeforeYouGoPage() {
         </div>
 
         {/* Medical Card */}
-        <div className="border border-border bg-card p-6">
-          <div className="mb-4 flex items-center gap-3">
-            <HeartPulse size={18} className="shrink-0 text-tactical" />
-            <h2 className="font-mono text-sm font-bold tracking-widest uppercase text-foreground">
-              Medical Card
-            </h2>
+        <div>
+          <div className="flex items-center gap-4 mb-6">
+            <div className="flex items-center justify-center w-14 h-14 border border-border bg-card">
+              <HeartPulse size={28} className="text-tactical" />
+            </div>
+            <div>
+              <h2 className="font-mono text-lg font-bold text-foreground">Medical Card</h2>
+              <p className="text-sm text-muted-foreground">Stays on your person the entire op</p>
+            </div>
           </div>
-          <div className="flex flex-col gap-3 text-sm leading-relaxed text-muted-foreground">
-            <p>
-              A medical card is a small piece of paper — laminated if you have it, written down if you don't — that stays on your person during the entire op. Sometimes cadre checks for it, sometimes they don't, but it's a listed item and more importantly it's a real safety tool.
+          <div className="flex flex-col gap-3 pl-[4.5rem]">
+            <p className="text-sm text-muted-foreground">
+              A small piece of paper — laminated if you have it, written if you don't. Cadre sometimes checks for it, but more importantly it's a real safety tool.
             </p>
-            <p>At minimum your medical card should include:</p>
-            <ul className="flex flex-col gap-1 pl-1">
+            <div className="grid gap-2 sm:grid-cols-2">
               {["Full name", "Home address", "Emergency contact name & phone number", "Any allergies", "Any medical conditions"].map((item) => (
-                <li key={item} className="flex items-center gap-2">
-                  <span className="text-tactical">—</span>
-                  <span>{item}</span>
-                </li>
+                <div key={item} className="flex items-center gap-3 border border-border bg-card px-4 py-3">
+                  <span className="text-tactical font-bold">—</span>
+                  <span className="text-sm text-muted-foreground">{item}</span>
+                </div>
               ))}
-            </ul>
-            <div className="mt-1 rounded border border-border bg-background px-3 py-2">
-              <span className="font-semibold text-foreground">Tip:</span> Keep both your deployment orders and medical card in the same ziplock bag and store it in your left shoulder pocket. If something happens in the field, that's the first place anyone is going to look — make it easy to find fast.
+            </div>
+            <div className="rounded border border-border bg-card px-4 py-3 text-sm text-muted-foreground">
+              <span className="font-semibold text-foreground">Tip:</span> Keep both your orders and medical card in the same ziplock bag in your left shoulder pocket. That's the first place anyone looks if something happens.
             </div>
           </div>
         </div>
 
         {/* Physical Fitness */}
-        <div className="border border-border bg-card p-6">
-          <div className="mb-4 flex items-center gap-3">
-            <Dumbbell size={18} className="shrink-0 text-tactical" />
-            <h2 className="font-mono text-sm font-bold tracking-widest uppercase text-foreground">
-              Physical Fitness
-            </h2>
+        <div>
+          <div className="flex items-center gap-4 mb-6">
+            <div className="flex items-center justify-center w-14 h-14 border border-border bg-card">
+              <Dumbbell size={28} className="text-tactical" />
+            </div>
+            <div>
+              <h2 className="font-mono text-lg font-bold text-foreground">Physical Fitness</h2>
+              <p className="text-sm text-muted-foreground">You're carrying kit for 24+ hours straight</p>
+            </div>
           </div>
-          <div className="flex flex-col gap-3 text-sm leading-relaxed text-muted-foreground">
-            <p>
+          <div className="flex flex-col gap-3 pl-[4.5rem]">
+            <p className="text-sm leading-relaxed text-muted-foreground">
               Milsim looks cool from the outside — and it is — but the physical reality hits different once you're in it. You're carrying a loaded vest and a replica for over 24 hours straight, moving through terrain, staying alert, and doing it all while sleep deprived. Body shock is real. People have blacked out and thrown up within the first 30 minutes. This isn't meant to scare you — it's meant to make sure you actually show up ready.
             </p>
-            <p>
+            <p className="text-sm leading-relaxed text-muted-foreground">
               Your fitness level directly affects your squad. One person who can't keep up slows everyone down and puts the team at a disadvantage. Start training with your actual gear — vest, replica, pack — so your body isn't shocked the moment the op starts. Put in the work before the event and you'll enjoy it a lot more.
             </p>
-            <div className="grid gap-2 sm:grid-cols-2">
+            <div className="grid gap-3 sm:grid-cols-2">
               {[
-                { label: "Go running", detail: "Be comfortable running 3 miles straight before the event. This op is a physical challenge — your cardio will be tested." },
-                { label: "Practice rucking", detail: "Rucking means moving with your full kit — replica, vest, and a loaded pack on your back. Depending on the event you could ruck anywhere from 2 to 8 miles in a single day. Get comfortable carrying that weight before you show up, not during." },
+                { label: "Go running", detail: "Be comfortable running 3 miles straight before the event. Your cardio will be tested." },
+                { label: "Practice rucking", detail: "Rucking means moving with your full kit — replica, vest, and a loaded pack. Depending on the event you could ruck 2–8 miles in a single day. Get comfortable carrying that weight before you show up, not during." },
                 { label: "Break in your boots", detail: "Do not show up in a fresh pair of boots. Wear them on runs and walks beforehand — blisters 10 hours into an op are brutal." },
                 { label: "Get sleep before", detail: "You're going to be up all night. Don't show up already running on empty." },
               ].map(({ label, detail }) => (
-                <div key={label} className="rounded border border-border bg-background p-3">
-                  <p className="font-semibold text-foreground">{label}</p>
-                  <p className="mt-1 text-xs leading-relaxed">{detail}</p>
+                <div key={label} className="border border-border bg-card p-4">
+                  <p className="font-mono text-sm font-bold text-tactical">{label}</p>
+                  <p className="mt-1.5 text-xs leading-relaxed text-muted-foreground">{detail}</p>
                 </div>
               ))}
             </div>
@@ -259,22 +265,18 @@ export default function BeforeYouGoPage() {
 
       </div>
 
-      {/* Packing checklist */}
-      <div className="mt-12">
-        <h2 className="mb-2 font-mono text-sm font-bold tracking-widest uppercase text-foreground">
-          // DAY-OF CHECKLIST
-        </h2>
-        <p className="mb-6 text-sm text-muted-foreground">
-          The essentials for arriving. For full loadout and faction-specific gear see the{" "}
-          <Link href="/newbie/milsim-west/gear" className="text-tactical hover:underline">
-            Gear Guide
-          </Link>.
-        </p>
+      {/* Checklist */}
+      <div className="mt-14">
+        <div className="flex items-center gap-3 mb-6">
+          <div className="h-px flex-1 bg-border" />
+          <h2 className="font-mono text-sm font-bold tracking-widest uppercase text-foreground">Day-Of Checklist</h2>
+          <div className="h-px flex-1 bg-border" />
+        </div>
         <div className="grid gap-2 sm:grid-cols-2">
-          {ARRIVAL_CHECKLIST.map((item) => (
-            <div key={item} className="flex items-start gap-3 border border-border bg-card p-3">
-              <CheckCircle2 size={15} className="mt-0.5 shrink-0 text-tactical" />
-              <span className="text-sm text-muted-foreground">{item}</span>
+          {ARRIVAL_CHECKLIST.map(({ icon: Icon, text }) => (
+            <div key={text} className="flex items-start gap-4 border border-border bg-card p-4">
+              <Icon size={18} className="mt-0.5 shrink-0 text-tactical" />
+              <span className="text-sm text-muted-foreground">{text}</span>
             </div>
           ))}
         </div>

--- a/app/newbie/milsim-west/gear/page.tsx
+++ b/app/newbie/milsim-west/gear/page.tsx
@@ -1,5 +1,9 @@
 import Link from "next/link";
-import { ChevronLeft, AlertTriangle, CheckCircle2, Package, Star, User } from "lucide-react";
+import {
+  ChevronLeft, AlertTriangle, CheckCircle2, Package, Star, User,
+  Shirt, Footprints, Eye, Crosshair, Flashlight, FileText,
+  HeartPulse, PenLine, Watch, Radio, Moon, Utensils, CloudRain, Trash2
+} from "lucide-react";
 import PageContainer from "@/components/layout/page-container";
 import type { Metadata } from "next";
 
@@ -10,58 +14,72 @@ export const metadata: Metadata = {
 
 const REQUIRED_GEAR = [
   {
+    icon: Shirt,
     item: "Uniform — correct faction camo",
     detail: "Matching top and bottom in your faction's approved pattern. NATO = Original Multicam only. RUSFOR = any Russian camo. Militia = US Woodland, solid green, or any RUSFOR camo. Wrong camo = turned away at the gate, no refund. Includes top, t-shirt, trousers with belt, and boots.",
   },
   {
+    icon: Footprints,
     item: "3x pairs of socks",
     detail: "Three pairs minimum — this is a red-line checked item. Wool or outdoor-rated socks, not cotton.",
   },
   {
+    icon: Eye,
     item: "Eye protection — full seal, ANSI rated",
     detail: "Must be ANSI Z87.1 rated and full seal (no gaps around the lens). On at all times — including while sleeping. This is the one item cadre takes most seriously.",
   },
   {
+    icon: Crosshair,
     item: "Primary replica + mags + battery + charger + sling",
     detail: "Correct replica for your faction. Fully charged battery. Bring your charger — you'll be on site for hours before the op starts. Mid-cap or standard magazines only (no box/drum mags unless you're running an LMG or MMG).",
   },
   {
-    item: "Flashlight or headlamp with red lens mode — you cannot play without this",
+    icon: Flashlight,
+    item: "Flashlight or headlamp with red lens mode",
     detail: "Red light is not optional. You cannot be on the field at night without one — cadre checks for it. Any red light works. Personally I recommend bringing two — someone on your team will forget theirs and you'll be glad you have a backup.",
   },
   {
+    icon: FileText,
     item: "Printed deployment orders + photo ID",
     detail: "Both must be on your person at all times — not in your pack. Keep them in a ziplock bag. See the Before You Go page for full details.",
   },
   {
+    icon: HeartPulse,
     item: "Medical card",
     detail: "In your left breast or shoulder pocket. Name, allergies, major medical conditions, current medications, and emergency contact info. Cadre knows where to look — make it easy to find.",
   },
   {
+    icon: PenLine,
     item: "Notepad and pen or pencil",
     detail: "For writing down orders, intel, frequencies, and call signs during the op.",
   },
   {
+    icon: Watch,
     item: "Wristwatch",
     detail: "Required to keep accurate track of time and the op schedule.",
   },
   {
+    icon: Radio,
     item: "Radio — FRS/GMRS (leadership only)",
     detail: "Required for Platoon Leaders, Platoon Sergeants, Squad Leaders, and Team Leaders. If you're not in a leadership role you don't need one, but your leaders do.",
   },
   {
+    icon: Moon,
     item: "Sleeping bag",
     detail: "Required at bag inspection. See the ruck section below for what kind to get.",
   },
   {
+    icon: Utensils,
     item: "Food and water for two days",
     detail: "Must be able to sustain yourself for the full event. Don't rely on resupply.",
   },
   {
+    icon: CloudRain,
     item: "Cold/wet weather gear",
     detail: "Checked at bag inspection. Required regardless of forecast — cadre enforces this.",
   },
   {
+    icon: Trash2,
     item: "2x heavy-duty garbage bags",
     detail: "MSW requires you to police call any area you rest in. Pack in, pack out.",
   },
@@ -78,84 +96,26 @@ const RUCK_ITEMS = [
 ];
 
 const FIELD_PICKS = [
-  {
-    label: "Electric hand warmers — bring two",
-    detail: "I bring two — one for my hands, one to tuck into my chest or sleeping bag. If you can keep your core warm, your whole body stays warm. Small, compact, rechargeable via USB. Bring a power bank.",
-  },
-  {
-    label: "Waterproof bivy or sleeping bag cover",
-    detail: "This is the one thing I wish I had on my first op. Rain puddles up and stays until the sun comes out. A bivy keeps you dry without setting up a shelter — and on the first night you're usually only getting 2–3 hours before you're moving out anyway.",
-  },
-  {
-    label: "Two ponchos minimum",
-    detail: "One covers your gear, one covers you. I use the button-clip kind that connect together. On fast nights when I know I'm moving out early, two ponchos thrown over me is the move — quick in, quick out.",
-  },
-  {
-    label: "Gore-Tex or waterproof jacket",
-    detail: "A poncho helps but it doesn't cover everything. I bring a Gore-Tex jacket to block wind and fill the gaps — it also doubles as an extra layer under my hoodie on cold nights. Carries on me or sits in my ruck either way.",
-  },
-  {
-    label: "Hoodie or fleece — faction colors",
-    detail: "Even desert events get brutally cold after dark when you're wet and not moving. I've seen four people quit at 2 AM on one op just from the cold. A mid-layer in your faction's color scheme is not optional — it's what keeps you in the fight.",
-  },
-  {
-    label: "Wool socks (x3) + one waterproof pair",
-    detail: "I bring three pairs of wool or outdoor-rated socks — not cotton, cotton stays wet. And at least one pair of waterproof hiking socks. On day two when my boots were soaked, those waterproof socks kept my feet completely dry inside the wet boot. Game changer.",
-  },
-  {
-    label: "Two pairs of gloves",
-    detail: "One field pair that's going to get wet and dirty, and one clean dry pair to rotate into at night or when the first pair is soaked. I learned this the hard way — running bare-handed out there is miserable.",
-  },
-  {
-    label: "Three batteries for your replica",
-    detail: "I bring three. One is none, two is one. My main battery failed mid-op once and my spare saved me — but I kept thinking what if that one dies too. Three means I always have something charged and ready. It's my primary weapon.",
-  },
-  {
-    label: "Military canteen",
-    detail: "I switched from a hydration pack on my vest after realizing how uncomfortable it was once my ruck went on — the pack behind my vest plus the ruck on my back was brutal. My military canteen clips to my belt or ruck instead. More flexible, much less annoying. I keep 20+ oz of water with electrolytes on me at all times.",
-  },
-  {
-    label: "MREs over camping/freeze-dried food",
-    detail: "I made the mistake of bringing camping food on my first op. Boiling water, soaking the food, eating — that whole process took 30–45 minutes. An MRE is a full meal, snack, and drink in under 30 with no setup. I switched to MREs and haven't looked back.",
-  },
-  {
-    label: "Electrolyte packs — this is a must, not a suggestion",
-    detail: "Drinking water by itself is not hydrating you. You must have electrolytes. I was drinking water constantly on my first op and still hallucinating — seeing people hiding behind trees that weren't there, hearing sounds that weren't happening. The dangerous part is you don't realize it's happening. There's no warning. It just starts and you don't even know when it began. I only figured it out when I noticed things that made no sense and started connecting the dots. Every time you refill your water, put an electrolyte packet in. LMNT, Liquid IV, anything. You are pushing your body way past its normal limits — water alone will not keep up with that.",
-  },
-  {
-    label: "Mini Cliff bars + GoGo Squeez applesauce",
-    detail: "For mornings when there's no time for an MRE. I keep mini Cliff bars in my cargo pockets — easier to eat fast than full-size, and gives you some protein. GoGo Squeez active applesauce has electrolytes built in, quick squeeze and done. Some mornings this is literally my breakfast. The goal is food you can eat in 60 seconds without stopping or needing water. Think like an ultra marathon runner — honey packets, Stroopwafels, honey energy chews, crackers with peanut butter packets, fruit strips. Soft, fast, and calorie-dense. Whatever works for you.",
-  },
-  {
-    label: "Caffeine — camping coffee + caffeine pouches",
-    detail: "When I have time in the morning I make coffee with camping coffee pouches — boil water, pour it through the pouch, done. It warms you up and gets you going, especially on cold mornings. When there's no time, I use nicotine-free caffeine pouches — 80mg of caffeine, mint flavored, which also helps with hygiene. If you're 21+ and use nicotine, pouches or patches work too. Don't overdo it — just enough to take the edge off when you need it.",
-  },
-  {
-    label: "Morale items — gum, candy, something you enjoy",
-    detail: "MREs come with gum — I save mine for when morale is lowest, usually right before a push. I bring extra and share with my squad. Sharing something small with your team genuinely helps. Talk to your teammates on downtime. Enjoy it — we're not Delta Force.",
-  },
-  {
-    label: "Face mask / lower face protection",
-    detail: "I always keep my mask on. I've seen people get teeth shot out at events — it happens. A lower face mask or mesh protects your face the same way eye pro protects your eyes. You can fix a tooth but it's better to just not.",
-  },
-  {
-    label: "Vitamin C and immune support",
-    detail: "Pushing this hard tanks your immune system fast. I start getting stuffy and run down when I overexert myself. If that happens to you out there, you're not alone — don't feel discouraged, you can still push through it. Take immune support before the event and bring some along to keep yourself going. Small thing, easy to forget.",
-  },
-  {
-    label: "Garmin watch",
-    detail: "I bring mine every op. I use it to track rucks, for the red torch at night, and for live tracking so my family knows I'm alive when there's no cell signal at the venue. Any watch works — but if you have a Garmin, bring it.",
-  },
-  {
-    label: "Compression underwear + hygiene basics",
-    detail: "You are not showering for three days and you're moving constantly. Regular cotton underwear will wreck you — chafing is a real problem most first-timers don't think about until it's too late. I wear Under Armour compression boxer briefs, the longer kind that reach the thighs. Breathable, moisture-wicking, no issues. I also pack dude wipes for a quick clean-up and baby powder for chafe prevention. Massive difference by day two.",
-  },
-  {
-    label: "Waterproof bag for your clothes and sleep system — this is a must",
-    detail: "Pack your sleeping bag and your sleep system in one garbage bag, and your extra clothes, socks, and hoodie in another. Your ruck can sit under a tree in the rain for hours — even with a rain cover, moisture comes up from the ground. If your sleeping bag and dry clothes are soaked, you have nothing. I bring the required 2 garbage bags for trash plus 2 more specifically for waterproofing my gear inside my ruck. Everything that needs to stay dry gets sealed before it goes in the pack.",
-  },
+  { label: "Electric hand warmers — bring two", detail: "I bring two — one for my hands, one to tuck into my chest or sleeping bag. If you can keep your core warm, your whole body stays warm. Small, compact, rechargeable via USB. Bring a power bank." },
+  { label: "Waterproof bivy or sleeping bag cover", detail: "This is the one thing I wish I had on my first op. Rain puddles up and stays until the sun comes out. A bivy keeps you dry without setting up a shelter — and on the first night you're usually only getting 2–3 hours before you're moving out anyway." },
+  { label: "Two ponchos minimum", detail: "One covers your gear, one covers you. I use the button-clip kind that connect together. On fast nights when I know I'm moving out early, two ponchos thrown over me is the move — quick in, quick out." },
+  { label: "Gore-Tex or waterproof jacket", detail: "A poncho helps but it doesn't cover everything. I bring a Gore-Tex jacket to block wind and fill the gaps — it also doubles as an extra layer under my hoodie on cold nights. Carries on me or sits in my ruck either way." },
+  { label: "Hoodie or fleece — faction colors", detail: "Even desert events get brutally cold after dark when you're wet and not moving. I've seen four people quit at 2 AM on one op just from the cold. A mid-layer in your faction's color scheme is not optional — it's what keeps you in the fight." },
+  { label: "Wool socks (x3) + one waterproof pair", detail: "I bring three pairs of wool or outdoor-rated socks — not cotton, cotton stays wet. And at least one pair of waterproof hiking socks. On day two when my boots were soaked, those waterproof socks kept my feet completely dry inside the wet boot. Game changer." },
+  { label: "Two pairs of gloves", detail: "One field pair that's going to get wet and dirty, and one clean dry pair to rotate into at night or when the first pair is soaked. I learned this the hard way — running bare-handed out there is miserable." },
+  { label: "Three batteries for your replica", detail: "I bring three. One is none, two is one. My main battery failed mid-op once and my spare saved me — but I kept thinking what if that one dies too. Three means I always have something charged and ready. It's my primary weapon." },
+  { label: "Military canteen", detail: "I switched from a hydration pack on my vest after realizing how uncomfortable it was once my ruck went on — the pack behind my vest plus the ruck on my back was brutal. My military canteen clips to my belt or ruck instead. More flexible, much less annoying. I keep 20+ oz of water with electrolytes on me at all times." },
+  { label: "MREs over camping/freeze-dried food", detail: "I made the mistake of bringing camping food on my first op. Boiling water, soaking the food, eating — that whole process took 30–45 minutes. An MRE is a full meal, snack, and drink in under 30 with no setup. I switched to MREs and haven't looked back." },
+  { label: "Electrolyte packs — this is a must, not a suggestion", detail: "Drinking water by itself is not hydrating you. You must have electrolytes. I was drinking water constantly on my first op and still hallucinating — seeing people hiding behind trees that weren't there, hearing sounds that weren't happening. The dangerous part is you don't realize it's happening. There's no warning. It just starts and you don't even know when it began. I only figured it out when I noticed things that made no sense and started connecting the dots. Every time you refill your water, put an electrolyte packet in. LMNT, Liquid IV, anything. You are pushing your body way past its normal limits — water alone will not keep up with that." },
+  { label: "Mini Cliff bars + GoGo Squeez applesauce", detail: "For mornings when there's no time for an MRE. I keep mini Cliff bars in my cargo pockets — easier to eat fast than full-size, and gives you some protein. GoGo Squeez active applesauce has electrolytes built in, quick squeeze and done. Some mornings this is literally my breakfast. The goal is food you can eat in 60 seconds without stopping or needing water. Think like an ultra marathon runner — honey packets, Stroopwafels, honey energy chews, crackers with peanut butter packets, fruit strips. Soft, fast, and calorie-dense. Whatever works for you." },
+  { label: "Caffeine — camping coffee + caffeine pouches", detail: "When I have time in the morning I make coffee with camping coffee pouches — boil water, pour it through the pouch, done. It warms you up and gets you going, especially on cold mornings. When there's no time, I use nicotine-free caffeine pouches — 80mg of caffeine, mint flavored, which also helps with hygiene. If you're 21+ and use nicotine, pouches or patches work too. Don't overdo it — just enough to take the edge off when you need it." },
+  { label: "Morale items — gum, candy, something you enjoy", detail: "MREs come with gum — I save mine for when morale is lowest, usually right before a push. I bring extra and share with my squad. Sharing something small with your team genuinely helps. Talk to your teammates on downtime. Enjoy it — we're not Delta Force." },
+  { label: "Face mask / lower face protection", detail: "I always keep my mask on. I've seen people get teeth shot out at events — it happens. A lower face mask or mesh protects your face the same way eye pro protects your eyes. You can fix a tooth but it's better to just not." },
+  { label: "Vitamin C and immune support", detail: "Pushing this hard tanks your immune system fast. I start getting stuffy and run down when I overexert myself. If that happens to you out there, you're not alone — don't feel discouraged, you can still push through it. Take immune support before the event and bring some along to keep yourself going. Small thing, easy to forget." },
+  { label: "Garmin watch", detail: "I bring mine every op. I use it to track rucks, for the red torch at night, and for live tracking so my family knows I'm alive when there's no cell signal at the venue. Any watch works — but if you have a Garmin, bring it." },
+  { label: "Compression underwear + hygiene basics", detail: "You are not showering for three days and you're moving constantly. Regular cotton underwear will wreck you — chafing is a real problem most first-timers don't think about until it's too late. I wear Under Armour compression boxer briefs, the longer kind that reach the thighs. Breathable, moisture-wicking, no issues. I also pack dude wipes for a quick clean-up and baby powder for chafe prevention. Massive difference by day two." },
+  { label: "Waterproof bag for your clothes and sleep system — this is a must", detail: "Pack your sleeping bag and your sleep system in one garbage bag, and your extra clothes, socks, and hoodie in another. Your ruck can sit under a tree in the rain for hours — even with a rain cover, moisture comes up from the ground. If your sleeping bag and dry clothes are soaked, you have nothing. I bring the required 2 garbage bags for trash plus 2 more specifically for waterproofing my gear inside my ruck. Everything that needs to stay dry gets sealed before it goes in the pack." },
 ];
-
 
 export default function GearPage() {
   return (
@@ -175,39 +135,39 @@ export default function GearPage() {
         directly affects how long you last. Start with what's required, then keep it practical.
       </p>
 
-      <div className="mt-12 flex flex-col gap-14">
+      <div className="mt-12 flex flex-col gap-16">
 
         {/* Required Gear */}
-        <div id="required">
-          <div className="mb-1 flex items-center gap-3">
-            <AlertTriangle size={16} className="shrink-0 text-tactical" />
-            <h2 className="font-mono text-sm font-bold tracking-widest uppercase text-foreground">
-              Required Gear — Bag Inspection
-            </h2>
+        <div>
+          <div className="flex items-center gap-3 mb-2">
+            <AlertTriangle size={16} className="text-tactical shrink-0" />
+            <h2 className="font-mono text-sm font-bold tracking-widest uppercase text-foreground">Required Gear — Bag Inspection</h2>
           </div>
-          <p className="mb-5 text-sm text-muted-foreground">
+          <p className="mb-6 text-sm text-muted-foreground">
             These are the red-line items cadre checks before you can play. Missing any of them means you are not getting in.
           </p>
-          <div className="grid gap-2 sm:grid-cols-2">
-            {REQUIRED_GEAR.map(({ item, detail }) => (
-              <div key={item} className="flex items-start gap-3 border border-border bg-card p-4">
-                <CheckCircle2 size={15} className="mt-0.5 shrink-0 text-tactical" />
-                <div>
-                  <p className="text-sm font-semibold text-foreground">{item}</p>
-                  <p className="mt-1 text-xs leading-relaxed text-muted-foreground">{detail}</p>
+          <div className="grid gap-3 sm:grid-cols-2">
+            {REQUIRED_GEAR.map(({ icon: Icon, item, detail }) => (
+              <div key={item} className="flex flex-col border border-border bg-card p-5 gap-4">
+                {/* Icon + title row */}
+                <div className="flex items-center gap-4">
+                  <div className="flex items-center justify-center w-12 h-12 shrink-0 bg-tactical/10 border border-tactical/20">
+                    <Icon size={22} className="text-tactical" />
+                  </div>
+                  <p className="text-sm font-bold text-foreground leading-snug">{item}</p>
                 </div>
+                {/* Detail */}
+                <p className="text-xs leading-relaxed text-muted-foreground border-t border-border pt-3">{detail}</p>
               </div>
             ))}
           </div>
         </div>
 
         {/* What to Keep On You */}
-        <div id="on-you">
-          <div className="mb-1 flex items-center gap-3">
-            <User size={16} className="shrink-0 text-tactical" />
-            <h2 className="font-mono text-sm font-bold tracking-widest uppercase text-foreground">
-              What to Keep On You
-            </h2>
+        <div>
+          <div className="flex items-center gap-3 mb-2">
+            <User size={16} className="text-tactical shrink-0" />
+            <h2 className="font-mono text-sm font-bold tracking-widest uppercase text-foreground">What to Keep On You</h2>
           </div>
           <div className="flex flex-col gap-3 text-sm leading-relaxed text-muted-foreground">
             <p>
@@ -223,19 +183,17 @@ export default function GearPage() {
               ammo bags, anything not already in your mags is fair game. Less weight also means more mobility
               — especially when you're rucking most of the time anyway. Save the energy for the actual movement.
             </p>
-            <div className="rounded border border-border bg-card px-3 py-2">
+            <div className="border-l-4 border-tactical bg-card px-4 py-3 text-sm">
               <span className="font-semibold text-foreground">The rule:</span> anything you might need fast goes on your person. Anything you can afford to not touch for a few hours goes in your ruck. If you have more to carry than your pockets fit, an assault pack is a valid option — just know the tradeoffs.
             </div>
           </div>
         </div>
 
         {/* The Ruck */}
-        <div id="ruck">
-          <div className="mb-1 flex items-center gap-3">
-            <Package size={16} className="shrink-0 text-tactical" />
-            <h2 className="font-mono text-sm font-bold tracking-widest uppercase text-foreground">
-              The Ruck — Get a Good One
-            </h2>
+        <div>
+          <div className="flex items-center gap-3 mb-2">
+            <Package size={16} className="text-tactical shrink-0" />
+            <h2 className="font-mono text-sm font-bold tracking-widest uppercase text-foreground">The Ruck — Get a Good One</h2>
           </div>
           <div className="flex flex-col gap-3 text-sm leading-relaxed text-muted-foreground">
             <p>
@@ -250,7 +208,7 @@ export default function GearPage() {
               have actually inspected packs at check-in for structural integrity because of exactly this.
               Get military surplus or a reputable brand. Surplus stores are your best value.
             </p>
-            <div className="flex items-start gap-3 rounded border border-tactical/40 bg-tactical/5 px-4 py-3">
+            <div className="flex items-start gap-3 border-l-4 border-tactical bg-tactical/5 px-4 py-3">
               <AlertTriangle size={14} className="mt-0.5 shrink-0 text-tactical" />
               <p className="text-sm leading-relaxed">
                 <span className="font-semibold text-foreground">You are not getting 8 hours of sleep.</span>{" "}
@@ -261,7 +219,7 @@ export default function GearPage() {
                 you can actually use your full sleep system — but the first night, keep it fast.
               </p>
             </div>
-            <div className="grid gap-2 sm:grid-cols-2 sm:grid-cols-3">
+            <div className="grid gap-2 sm:grid-cols-2 mt-2">
               {RUCK_ITEMS.map(({ label, detail }) => (
                 <div key={label} className="flex items-start gap-3 border border-border bg-card p-4">
                   <CheckCircle2 size={15} className="mt-0.5 shrink-0 text-tactical" />
@@ -276,26 +234,27 @@ export default function GearPage() {
         </div>
 
         {/* Field-Tested Picks */}
-        <div id="field-picks">
-          <div className="mb-1 flex items-center gap-3">
-            <Star size={16} className="shrink-0 text-tactical" />
-            <h2 className="font-mono text-sm font-bold tracking-widest uppercase text-foreground">
-              Field-Tested Picks
-            </h2>
+        <div>
+          <div className="flex items-center gap-3 mb-2">
+            <Star size={16} className="text-tactical shrink-0" />
+            <h2 className="font-mono text-sm font-bold tracking-widest uppercase text-foreground">Field-Tested Picks</h2>
           </div>
-          <p className="mb-5 text-sm text-muted-foreground">
+          <p className="mb-6 text-sm text-muted-foreground">
             Not required — this is what I personally bring and swear by. Stuff that made a real difference once I was 20 hours in and the wheels started coming off.
           </p>
-          <div className="grid gap-2 sm:grid-cols-2">
+          <div className="grid gap-3 sm:grid-cols-2">
             {FIELD_PICKS.map(({ label, detail }) => (
-              <div key={label} className="rounded border border-border bg-card p-4">
-                <p className="font-semibold text-foreground text-sm">{label}</p>
-                <p className="mt-2 text-xs leading-relaxed text-muted-foreground">{detail}</p>
+              <div key={label} className="border border-border bg-card p-5">
+                <div className="flex items-center gap-2 mb-3">
+                  <Star size={11} className="shrink-0 text-tactical fill-tactical" />
+                  <p className="font-mono text-xs font-bold text-foreground uppercase tracking-wide leading-snug">{label}</p>
+                </div>
+                <p className="text-xs leading-relaxed text-muted-foreground">{detail}</p>
               </div>
             ))}
           </div>
 
-          <div className="mt-4 rounded border border-border bg-card p-4">
+          <div className="mt-4 border-l-4 border-tactical bg-card px-5 py-4">
             <p className="text-sm font-semibold text-foreground mb-1">Before the op: carb load</p>
             <p className="text-xs leading-relaxed text-muted-foreground">
               The night before or the morning of, eat a real carb-heavy meal — bread, pizza, burgers, whatever works. You are going to burn through carbs at a rate way above normal. Loading up beforehand means your body already has fuel in reserve when the op starts and you don't have time to eat. It makes a noticeable difference in how long you last before hitting the wall.

--- a/app/newbie/milsim-west/page.tsx
+++ b/app/newbie/milsim-west/page.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link";
-import { ChevronRight, ChevronLeft, ListChecks, Backpack, Crosshair, Radio, FileText, Users } from "lucide-react";
+import { ChevronLeft, ListChecks, Backpack, Crosshair, Radio, FileText, Users } from "lucide-react";
 import PageContainer from "@/components/layout/page-container";
 import type { Metadata } from "next";
 
@@ -49,7 +49,7 @@ const SECTIONS = [
     number: "06",
     Icon: Users,
     title: "Factions",
-    description: "NATO, RUFOR, and who else is on the field. Know your side before you show up.",
+    description: "NATO, RUFOR, and Militia. Know your side before you show up.",
   },
 ];
 
@@ -80,27 +80,29 @@ export default function MilsimWestPage() {
           <Link
             key={slug}
             href={`/newbie/milsim-west/${slug}`}
-            className="group relative flex flex-col gap-4 border border-border bg-card p-5 transition-all hover:border-tactical hover:-translate-y-0.5 hover:shadow-lg"
+            className="group relative flex flex-col gap-6 border border-border bg-card p-7 transition-all hover:border-tactical hover:-translate-y-0.5 hover:shadow-lg"
           >
-            {/* Icon — inherits foreground color, goes red in dark mode automatically */}
-            <Icon size={28} className="text-foreground transition-colors group-hover:text-tactical" />
-
-            <span className="absolute right-4 top-4 font-mono text-xs text-muted-foreground/40">
+            {/* Number */}
+            <span className="absolute right-5 top-5 font-mono text-xs font-bold text-muted-foreground/30">
               {number}
             </span>
+
+            {/* Icon block */}
+            <div className="flex items-center justify-center w-14 h-14 border border-border bg-background group-hover:border-tactical group-hover:bg-tactical/5 transition-all">
+              <Icon size={28} className="text-foreground transition-colors group-hover:text-tactical" />
+            </div>
 
             <div>
               <h2 className="font-mono text-base font-bold text-foreground transition-colors group-hover:text-tactical">
                 {title}
               </h2>
-              <p className="mt-1.5 text-sm leading-relaxed text-muted-foreground">
+              <p className="mt-2 text-sm leading-relaxed text-muted-foreground">
                 {description}
               </p>
             </div>
 
-            <div className="mt-auto flex items-center gap-1 font-mono text-xs tracking-widest uppercase text-tactical opacity-0 transition-opacity group-hover:opacity-100">
-              OPEN <ChevronRight size={12} />
-            </div>
+            {/* Bottom tactical bar — animates in on hover */}
+            <div className="absolute bottom-0 left-0 right-0 h-0.5 bg-tactical scale-x-0 group-hover:scale-x-100 transition-transform origin-left" />
           </Link>
         ))}
       </div>

--- a/components/layout/hero.tsx
+++ b/components/layout/hero.tsx
@@ -38,12 +38,6 @@ export default function Hero() {
         >
           GET BRIEFED
         </Link>
-        <Link
-          href="/events"
-          className="inline-block border border-border px-8 py-3 font-mono text-xs font-bold tracking-widest uppercase text-muted-foreground transition-colors hover:border-tactical hover:text-tactical"
-        >
-          VIEW EVENTS
-        </Link>
       </div>
 
       {/* Bottom fade */}


### PR DESCRIPTION
## Summary
- Before You Go: icon section headers, large time stat blocks (1400/1800/2200), left-border warning banners
- Gear Guide: individual icon cards for all 14 required gear items, section banners, star grid for field picks
- Milsim West index: larger icon boxes with tactical fill on hover, bottom bar animation
- Hero: removed events button

🤖 Generated with [Claude Code](https://claude.com/claude-code)