### PR TITLE
add feature badges to hero

### DIFF
--- a/components/layout/hero.tsx
+++ b/components/layout/hero.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import { WifiOff, FileDown, Eye } from "lucide-react";
 
 export default function Hero() {
   return (
@@ -31,7 +32,25 @@ export default function Hero() {
         be the one who quits on day one.
       </p>
 
-      <div className="mt-10 flex flex-col items-center gap-3 sm:flex-row">
+      {/* Feature badges */}
+      <div className="mt-10 flex flex-col items-center gap-3">
+        <div className="flex flex-wrap items-center justify-center gap-3">
+          <div className="flex items-center gap-2 border border-border px-3 py-2 text-xs text-muted-foreground">
+            <WifiOff size={13} className="text-tactical" />
+            <span>Works offline — no signal needed in the field</span>
+          </div>
+          <div className="flex items-center gap-2 border border-border px-3 py-2 text-xs text-muted-foreground">
+            <FileDown size={13} className="text-tactical" />
+            <span>Download a PDF field guide before you go</span>
+          </div>
+        </div>
+        <div className="flex items-center gap-2 border border-border px-3 py-2 text-xs text-muted-foreground">
+          <Eye size={13} className="text-tactical" />
+          <span>Red light mode — preserves your night vision in the field</span>
+        </div>
+      </div>
+
+      <div className="mt-4 flex flex-col items-center gap-3 sm:flex-row">
         <Link
           href="/newbie"
           className="inline-block bg-tactical px-8 py-3 font-mono text-xs font-bold tracking-widest uppercase text-tactical-foreground transition-opacity hover:opacity-80"


### PR DESCRIPTION
## Summary
- Added offline mode, PDF download, and red light mode badges below the hero headline
- Red light mode badge explains the tactical color scheme to new visitors

## Test plan
- [ ] All three badges visible on hero
- [ ] Red light mode badge sits on its own row below the other two